### PR TITLE
Correct exception message for 400 status upload

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -121,7 +121,8 @@ class Client
         }
 
         if (400 === $response->getStatusCode()) {
-            throw new Exception('Checksum and file contents mismatched');
+            $responseBody = json_decode($response->getBody()->getContents(), true);
+            throw new Exception($responseBody['Message'] ?? 'Checksum and file contents mismatched');
         }
 
         if (201 === $response->getStatusCode()) {


### PR DESCRIPTION
Addresses issue #15 

When we attempt to upload and get a 400 response code, instead of (sometimes) incorrectly stating the issue is due to checksum mismatch, we get the actual message from the body of the response and use that as the exception message instead.