### PR TITLE
docs(examples): add code examples

### DIFF
--- a/examples/async-upload/README.md
+++ b/examples/async-upload/README.md
@@ -1,0 +1,62 @@
+# Async Upload Example
+
+This example demonstrates how to upload multiple files concurrently using async/await with Guzzle promises.
+
+## Prerequisites
+
+- PHP 8.1 or higher
+- Composer
+- A Bunny Storage zone with API credentials
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+composer install
+```
+
+2. Set the required environment variables:
+
+```bash
+export BUNNY_STORAGE_API_KEY="your-storage-api-key"
+export BUNNY_STORAGE_ZONE="your-storage-zone-name"
+export BUNNY_STORAGE_REGION="de"  # Optional, defaults to "de" (Falkenstein)
+```
+
+3. Create a local `files` directory with files to upload:
+
+```bash
+mkdir files
+# Add some files to upload
+```
+
+## Running the Example
+
+Run directly with PHP:
+
+```bash
+BUNNY_STORAGE_API_KEY="your-key" BUNNY_STORAGE_ZONE="your-zone" php index.php
+```
+
+Or start a local server:
+
+```bash
+BUNNY_STORAGE_API_KEY="your-key" BUNNY_STORAGE_ZONE="your-zone" composer start
+```
+
+Then visit http://localhost:8000 in your browser.
+
+## What This Example Does
+
+1. Scans the local `files/` directory for files
+2. Creates async upload promises for each file
+3. Executes all uploads concurrently
+4. Reports progress and results for each file
+5. Compares execution time with sequential uploads
+
+## Benefits of Async Uploads
+
+- **Faster**: Multiple files upload simultaneously instead of one at a time
+- **Efficient**: Better utilization of network bandwidth
+- **Scalable**: Handle large numbers of files more effectively

--- a/examples/async-upload/composer.json
+++ b/examples/async-upload/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "bunnycdn/storage-example-async-upload",
+    "description": "Async upload example for Bunny Storage SDK",
+    "type": "project",
+    "require": {
+        "php": ">=8.1",
+        "bunnycdn/storage": "*"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../"
+        }
+    ],
+    "scripts": {
+        "start": "php -S localhost:8000 index.php"
+    }
+}

--- a/examples/async-upload/index.php
+++ b/examples/async-upload/index.php
@@ -1,0 +1,143 @@
+<?php
+
+require_once __DIR__ . "/../../vendor/autoload.php";
+
+use Bunny\Storage\Client;
+use Bunny\Storage\Region;
+use GuzzleHttp\Promise\Utils;
+
+$apiKey = getenv("BUNNY_STORAGE_API_KEY");
+$storageZone = getenv("BUNNY_STORAGE_ZONE");
+$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+
+if (!$apiKey || !$storageZone) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "error" =>
+                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+$regionMap = [
+    "de" => Region::FALKENSTEIN,
+    "uk" => Region::LONDON,
+    "se" => Region::STOCKHOLM,
+    "ny" => Region::NEW_YORK,
+    "la" => Region::LOS_ANGELES,
+    "sg" => Region::SINGAPORE,
+    "syd" => Region::SYDNEY,
+    "br" => Region::SAO_PAULO,
+    "jh" => Region::JOHANNESBURG,
+];
+
+$regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
+
+$localDirectory = __DIR__ . "/files";
+
+if (!is_dir($localDirectory)) {
+    mkdir($localDirectory, 0755, true);
+
+    for ($i = 1; $i <= 5; $i++) {
+        $content = str_repeat("This is sample file {$i}. ", 100 * $i);
+        file_put_contents("{$localDirectory}/async-sample{$i}.txt", $content);
+    }
+}
+
+try {
+    $client = new Client($apiKey, $storageZone, $regionConstant);
+
+    $files = glob("{$localDirectory}/*");
+    $files = array_filter($files, "is_file");
+
+    if (empty($files)) {
+        header("Content-Type: application/json");
+        echo json_encode(
+            [
+                "error" => "No files found in '{$localDirectory}'. Add some files to the 'files/' directory and run again.",
+            ],
+            JSON_PRETTY_PRINT,
+        );
+        exit(0);
+    }
+
+    $uploadMap = [];
+    foreach ($files as $file) {
+        $fileName = basename($file);
+        $remotePath = "async/{$fileName}";
+        $uploadMap[$file] = $remotePath;
+    }
+
+    $asyncStart = microtime(true);
+
+    $promises = [];
+    foreach ($uploadMap as $localPath => $remotePath) {
+        $promises[$remotePath] = $client->uploadAsync($localPath, $remotePath);
+    }
+
+    $promiseResults = Utils::settle($promises)->wait();
+
+    $asyncEnd = microtime(true);
+    $asyncDuration = round($asyncEnd - $asyncStart, 3);
+
+    $results = [];
+    $successful = 0;
+    $failed = 0;
+
+    foreach ($promiseResults as $remotePath => $result) {
+        $fileName = basename($remotePath);
+        $localPath = array_search($remotePath, $uploadMap);
+
+        if ($result["state"] === "fulfilled") {
+            $results[] = [
+                "file" => $fileName,
+                "size" => filesize($localPath),
+                "status" => "success",
+            ];
+            $successful++;
+        } else {
+            $results[] = [
+                "file" => $fileName,
+                "size" => filesize($localPath),
+                "status" => "failed",
+                "error" => $result["reason"]->getMessage(),
+            ];
+            $failed++;
+        }
+    }
+
+    $uploadedFiles = $client->listFiles("async/");
+    $uploadedList = array_map(
+        fn($file) => [
+            "name" => $file->getName(),
+            "size" => $file->getSize(),
+            "isDirectory" => $file->isDirectory(),
+            "dateModified" => $file->getDateModified()->format("c"),
+        ],
+        array_filter($uploadedFiles, fn($file) => !$file->isDirectory()),
+    );
+
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "storageZone" => $storageZone,
+            "region" => $region,
+            "summary" => [
+                "successful" => $successful,
+                "failed" => $failed,
+                "total" => count($files),
+                "durationSeconds" => $asyncDuration,
+            ],
+            "results" => $results,
+            "uploadedFiles" => array_values($uploadedList),
+        ],
+        JSON_PRETTY_PRINT,
+    );
+} catch (Exception $e) {
+    header("Content-Type: application/json");
+    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    exit(1);
+}

--- a/examples/async-upload/index.php
+++ b/examples/async-upload/index.php
@@ -1,21 +1,20 @@
 <?php
 
-require_once __DIR__ . "/../../vendor/autoload.php";
+require_once __DIR__.'/../../vendor/autoload.php';
 
 use Bunny\Storage\Client;
 use Bunny\Storage\Region;
 use GuzzleHttp\Promise\Utils;
 
-$apiKey = getenv("BUNNY_STORAGE_API_KEY");
-$storageZone = getenv("BUNNY_STORAGE_ZONE");
-$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+$apiKey = getenv('BUNNY_STORAGE_API_KEY');
+$storageZone = getenv('BUNNY_STORAGE_ZONE');
+$region = getenv('BUNNY_STORAGE_REGION') ?: 'de';
 
 if (!$apiKey || !$storageZone) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "error" =>
-                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+            'error' => 'BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.',
         ],
         JSON_PRETTY_PRINT,
     );
@@ -23,25 +22,25 @@ if (!$apiKey || !$storageZone) {
 }
 
 $regionMap = [
-    "de" => Region::FALKENSTEIN,
-    "uk" => Region::LONDON,
-    "se" => Region::STOCKHOLM,
-    "ny" => Region::NEW_YORK,
-    "la" => Region::LOS_ANGELES,
-    "sg" => Region::SINGAPORE,
-    "syd" => Region::SYDNEY,
-    "br" => Region::SAO_PAULO,
-    "jh" => Region::JOHANNESBURG,
+    'de' => Region::FALKENSTEIN,
+    'uk' => Region::LONDON,
+    'se' => Region::STOCKHOLM,
+    'ny' => Region::NEW_YORK,
+    'la' => Region::LOS_ANGELES,
+    'sg' => Region::SINGAPORE,
+    'syd' => Region::SYDNEY,
+    'br' => Region::SAO_PAULO,
+    'jh' => Region::JOHANNESBURG,
 ];
 
 $regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
 
-$localDirectory = __DIR__ . "/files";
+$localDirectory = __DIR__.'/files';
 
 if (!is_dir($localDirectory)) {
     mkdir($localDirectory, 0755, true);
 
-    for ($i = 1; $i <= 5; $i++) {
+    for ($i = 1; $i <= 5; ++$i) {
         $content = str_repeat("This is sample file {$i}. ", 100 * $i);
         file_put_contents("{$localDirectory}/async-sample{$i}.txt", $content);
     }
@@ -51,13 +50,13 @@ try {
     $client = new Client($apiKey, $storageZone, $regionConstant);
 
     $files = glob("{$localDirectory}/*");
-    $files = array_filter($files, "is_file");
+    $files = array_filter($files, 'is_file');
 
     if (empty($files)) {
-        header("Content-Type: application/json");
+        header('Content-Type: application/json');
         echo json_encode(
             [
-                "error" => "No files found in '{$localDirectory}'. Add some files to the 'files/' directory and run again.",
+                'error' => "No files found in '{$localDirectory}'. Add some files to the 'files/' directory and run again.",
             ],
             JSON_PRETTY_PRINT,
         );
@@ -91,53 +90,53 @@ try {
         $fileName = basename($remotePath);
         $localPath = array_search($remotePath, $uploadMap);
 
-        if ($result["state"] === "fulfilled") {
+        if ('fulfilled' === $result['state']) {
             $results[] = [
-                "file" => $fileName,
-                "size" => filesize($localPath),
-                "status" => "success",
+                'file' => $fileName,
+                'size' => filesize($localPath),
+                'status' => 'success',
             ];
-            $successful++;
+            ++$successful;
         } else {
             $results[] = [
-                "file" => $fileName,
-                "size" => filesize($localPath),
-                "status" => "failed",
-                "error" => $result["reason"]->getMessage(),
+                'file' => $fileName,
+                'size' => filesize($localPath),
+                'status' => 'failed',
+                'error' => $result['reason']->getMessage(),
             ];
-            $failed++;
+            ++$failed;
         }
     }
 
-    $uploadedFiles = $client->listFiles("async/");
+    $uploadedFiles = $client->listFiles('async/');
     $uploadedList = array_map(
-        fn($file) => [
-            "name" => $file->getName(),
-            "size" => $file->getSize(),
-            "isDirectory" => $file->isDirectory(),
-            "dateModified" => $file->getDateModified()->format("c"),
+        fn ($file) => [
+            'name' => $file->getName(),
+            'size' => $file->getSize(),
+            'isDirectory' => $file->isDirectory(),
+            'dateModified' => $file->getDateModified()->format('c'),
         ],
-        array_filter($uploadedFiles, fn($file) => !$file->isDirectory()),
+        array_filter($uploadedFiles, fn ($file) => !$file->isDirectory()),
     );
 
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "storageZone" => $storageZone,
-            "region" => $region,
-            "summary" => [
-                "successful" => $successful,
-                "failed" => $failed,
-                "total" => count($files),
-                "durationSeconds" => $asyncDuration,
+            'storageZone' => $storageZone,
+            'region' => $region,
+            'summary' => [
+                'successful' => $successful,
+                'failed' => $failed,
+                'total' => count($files),
+                'durationSeconds' => $asyncDuration,
             ],
-            "results" => $results,
-            "uploadedFiles" => array_values($uploadedList),
+            'results' => $results,
+            'uploadedFiles' => array_values($uploadedList),
         ],
         JSON_PRETTY_PRINT,
     );
 } catch (Exception $e) {
-    header("Content-Type: application/json");
-    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => $e->getMessage()], JSON_PRETTY_PRINT);
     exit(1);
 }

--- a/examples/batch-upload/README.md
+++ b/examples/batch-upload/README.md
@@ -1,0 +1,57 @@
+# Batch Upload Example
+
+This example demonstrates how to upload multiple files from a local directory to Bunny Storage.
+
+## Prerequisites
+
+- PHP 8.1 or higher
+- Composer
+- A Bunny Storage zone with API credentials
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+composer install
+```
+
+2. Set the required environment variables:
+
+```bash
+export BUNNY_STORAGE_API_KEY="your-storage-api-key"
+export BUNNY_STORAGE_ZONE="your-storage-zone-name"
+export BUNNY_STORAGE_REGION="de"  # Optional, defaults to "de" (Falkenstein)
+```
+
+3. Create a local `files` directory with files to upload:
+
+```bash
+mkdir files
+echo "File 1 content" > files/file1.txt
+echo "File 2 content" > files/file2.txt
+echo "File 3 content" > files/file3.txt
+```
+
+## Running the Example
+
+Run directly with PHP:
+
+```bash
+BUNNY_STORAGE_API_KEY="your-key" BUNNY_STORAGE_ZONE="your-zone" php index.php
+```
+
+Or start a local server:
+
+```bash
+BUNNY_STORAGE_API_KEY="your-key" BUNNY_STORAGE_ZONE="your-zone" composer start
+```
+
+Then visit http://localhost:8000 in your browser.
+
+## What This Example Does
+
+1. Scans the local `files/` directory for files
+2. Uploads each file to Bunny Storage in a `batch/` directory
+3. Reports progress and results for each file
+4. Shows a summary of successful and failed uploads

--- a/examples/batch-upload/composer.json
+++ b/examples/batch-upload/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "bunnycdn/storage-example-batch-upload",
+    "description": "Batch upload example for Bunny Storage SDK",
+    "type": "project",
+    "require": {
+        "php": ">=8.1",
+        "bunnycdn/storage": "*"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../"
+        }
+    ],
+    "scripts": {
+        "start": "php -S localhost:8000 index.php"
+    }
+}

--- a/examples/batch-upload/index.php
+++ b/examples/batch-upload/index.php
@@ -1,20 +1,19 @@
 <?php
 
-require_once __DIR__ . "/../../vendor/autoload.php";
+require_once __DIR__.'/../../vendor/autoload.php';
 
 use Bunny\Storage\Client;
 use Bunny\Storage\Region;
 
-$apiKey = getenv("BUNNY_STORAGE_API_KEY");
-$storageZone = getenv("BUNNY_STORAGE_ZONE");
-$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+$apiKey = getenv('BUNNY_STORAGE_API_KEY');
+$storageZone = getenv('BUNNY_STORAGE_ZONE');
+$region = getenv('BUNNY_STORAGE_REGION') ?: 'de';
 
 if (!$apiKey || !$storageZone) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "error" =>
-                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+            'error' => 'BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.',
         ],
         JSON_PRETTY_PRINT,
     );
@@ -22,35 +21,35 @@ if (!$apiKey || !$storageZone) {
 }
 
 $regionMap = [
-    "de" => Region::FALKENSTEIN,
-    "uk" => Region::LONDON,
-    "se" => Region::STOCKHOLM,
-    "ny" => Region::NEW_YORK,
-    "la" => Region::LOS_ANGELES,
-    "sg" => Region::SINGAPORE,
-    "syd" => Region::SYDNEY,
-    "br" => Region::SAO_PAULO,
-    "jh" => Region::JOHANNESBURG,
+    'de' => Region::FALKENSTEIN,
+    'uk' => Region::LONDON,
+    'se' => Region::STOCKHOLM,
+    'ny' => Region::NEW_YORK,
+    'la' => Region::LOS_ANGELES,
+    'sg' => Region::SINGAPORE,
+    'syd' => Region::SYDNEY,
+    'br' => Region::SAO_PAULO,
+    'jh' => Region::JOHANNESBURG,
 ];
 
 $regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
 
-$localDirectory = __DIR__ . "/files";
+$localDirectory = __DIR__.'/files';
 
 if (!is_dir($localDirectory)) {
     mkdir($localDirectory, 0755, true);
 
     file_put_contents(
         "{$localDirectory}/sample1.txt",
-        "This is sample file 1. Created at: " . date("Y-m-d H:i:s"),
+        'This is sample file 1. Created at: '.date('Y-m-d H:i:s'),
     );
     file_put_contents(
         "{$localDirectory}/sample2.txt",
-        "This is sample file 2. Created at: " . date("Y-m-d H:i:s"),
+        'This is sample file 2. Created at: '.date('Y-m-d H:i:s'),
     );
     file_put_contents(
         "{$localDirectory}/sample3.txt",
-        "This is sample file 3. Created at: " . date("Y-m-d H:i:s"),
+        'This is sample file 3. Created at: '.date('Y-m-d H:i:s'),
     );
 }
 
@@ -58,13 +57,13 @@ try {
     $client = new Client($apiKey, $storageZone, $regionConstant);
 
     $files = glob("{$localDirectory}/*");
-    $files = array_filter($files, "is_file");
+    $files = array_filter($files, 'is_file');
 
     if (empty($files)) {
-        header("Content-Type: application/json");
+        header('Content-Type: application/json');
         echo json_encode(
             [
-                "error" => "No files found in '{$localDirectory}'. Add some files to the 'files/' directory and run again.",
+                'error' => "No files found in '{$localDirectory}'. Add some files to the 'files/' directory and run again.",
             ],
             JSON_PRETTY_PRINT,
         );
@@ -82,50 +81,50 @@ try {
         try {
             $client->upload($file, $remotePath);
             $results[] = [
-                "file" => $fileName,
-                "size" => filesize($file),
-                "status" => "success",
+                'file' => $fileName,
+                'size' => filesize($file),
+                'status' => 'success',
             ];
-            $successful++;
+            ++$successful;
         } catch (Exception $e) {
             $results[] = [
-                "file" => $fileName,
-                "size" => filesize($file),
-                "status" => "failed",
-                "error" => $e->getMessage(),
+                'file' => $fileName,
+                'size' => filesize($file),
+                'status' => 'failed',
+                'error' => $e->getMessage(),
             ];
-            $failed++;
+            ++$failed;
         }
     }
 
-    $uploadedFiles = $client->listFiles("batch/");
+    $uploadedFiles = $client->listFiles('batch/');
     $uploadedList = array_map(
-        fn($file) => [
-            "name" => $file->getName(),
-            "size" => $file->getSize(),
-            "isDirectory" => $file->isDirectory(),
-            "dateModified" => $file->getDateModified()->format("c"),
+        fn ($file) => [
+            'name' => $file->getName(),
+            'size' => $file->getSize(),
+            'isDirectory' => $file->isDirectory(),
+            'dateModified' => $file->getDateModified()->format('c'),
         ],
-        array_filter($uploadedFiles, fn($file) => !$file->isDirectory()),
+        array_filter($uploadedFiles, fn ($file) => !$file->isDirectory()),
     );
 
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "storageZone" => $storageZone,
-            "region" => $region,
-            "summary" => [
-                "successful" => $successful,
-                "failed" => $failed,
-                "total" => count($files),
+            'storageZone' => $storageZone,
+            'region' => $region,
+            'summary' => [
+                'successful' => $successful,
+                'failed' => $failed,
+                'total' => count($files),
             ],
-            "results" => $results,
-            "uploadedFiles" => array_values($uploadedList),
+            'results' => $results,
+            'uploadedFiles' => array_values($uploadedList),
         ],
         JSON_PRETTY_PRINT,
     );
 } catch (Exception $e) {
-    header("Content-Type: application/json");
-    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => $e->getMessage()], JSON_PRETTY_PRINT);
     exit(1);
 }

--- a/examples/batch-upload/index.php
+++ b/examples/batch-upload/index.php
@@ -1,0 +1,131 @@
+<?php
+
+require_once __DIR__ . "/../../vendor/autoload.php";
+
+use Bunny\Storage\Client;
+use Bunny\Storage\Region;
+
+$apiKey = getenv("BUNNY_STORAGE_API_KEY");
+$storageZone = getenv("BUNNY_STORAGE_ZONE");
+$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+
+if (!$apiKey || !$storageZone) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "error" =>
+                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+$regionMap = [
+    "de" => Region::FALKENSTEIN,
+    "uk" => Region::LONDON,
+    "se" => Region::STOCKHOLM,
+    "ny" => Region::NEW_YORK,
+    "la" => Region::LOS_ANGELES,
+    "sg" => Region::SINGAPORE,
+    "syd" => Region::SYDNEY,
+    "br" => Region::SAO_PAULO,
+    "jh" => Region::JOHANNESBURG,
+];
+
+$regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
+
+$localDirectory = __DIR__ . "/files";
+
+if (!is_dir($localDirectory)) {
+    mkdir($localDirectory, 0755, true);
+
+    file_put_contents(
+        "{$localDirectory}/sample1.txt",
+        "This is sample file 1. Created at: " . date("Y-m-d H:i:s"),
+    );
+    file_put_contents(
+        "{$localDirectory}/sample2.txt",
+        "This is sample file 2. Created at: " . date("Y-m-d H:i:s"),
+    );
+    file_put_contents(
+        "{$localDirectory}/sample3.txt",
+        "This is sample file 3. Created at: " . date("Y-m-d H:i:s"),
+    );
+}
+
+try {
+    $client = new Client($apiKey, $storageZone, $regionConstant);
+
+    $files = glob("{$localDirectory}/*");
+    $files = array_filter($files, "is_file");
+
+    if (empty($files)) {
+        header("Content-Type: application/json");
+        echo json_encode(
+            [
+                "error" => "No files found in '{$localDirectory}'. Add some files to the 'files/' directory and run again.",
+            ],
+            JSON_PRETTY_PRINT,
+        );
+        exit(0);
+    }
+
+    $results = [];
+    $successful = 0;
+    $failed = 0;
+
+    foreach ($files as $file) {
+        $fileName = basename($file);
+        $remotePath = "batch/{$fileName}";
+
+        try {
+            $client->upload($file, $remotePath);
+            $results[] = [
+                "file" => $fileName,
+                "size" => filesize($file),
+                "status" => "success",
+            ];
+            $successful++;
+        } catch (Exception $e) {
+            $results[] = [
+                "file" => $fileName,
+                "size" => filesize($file),
+                "status" => "failed",
+                "error" => $e->getMessage(),
+            ];
+            $failed++;
+        }
+    }
+
+    $uploadedFiles = $client->listFiles("batch/");
+    $uploadedList = array_map(
+        fn($file) => [
+            "name" => $file->getName(),
+            "size" => $file->getSize(),
+            "isDirectory" => $file->isDirectory(),
+            "dateModified" => $file->getDateModified()->format("c"),
+        ],
+        array_filter($uploadedFiles, fn($file) => !$file->isDirectory()),
+    );
+
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "storageZone" => $storageZone,
+            "region" => $region,
+            "summary" => [
+                "successful" => $successful,
+                "failed" => $failed,
+                "total" => count($files),
+            ],
+            "results" => $results,
+            "uploadedFiles" => array_values($uploadedList),
+        ],
+        JSON_PRETTY_PRINT,
+    );
+} catch (Exception $e) {
+    header("Content-Type: application/json");
+    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    exit(1);
+}

--- a/examples/delete-file/README.md
+++ b/examples/delete-file/README.md
@@ -1,0 +1,50 @@
+# Delete File Example
+
+This example demonstrates how to delete files and directories from Bunny Storage.
+
+## Prerequisites
+
+- PHP 8.1 or higher
+- Composer
+- A Bunny Storage zone with API credentials
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+composer install
+```
+
+2. Set the required environment variables:
+
+```bash
+export BUNNY_STORAGE_API_KEY="your-storage-api-key"
+export BUNNY_STORAGE_ZONE="your-storage-zone-name"
+export BUNNY_STORAGE_REGION="de"  # Optional, defaults to "de" (Falkenstein)
+```
+
+## Running the Example
+
+Run directly with PHP:
+
+```bash
+BUNNY_STORAGE_API_KEY="your-key" BUNNY_STORAGE_ZONE="your-zone" php index.php
+```
+
+Or start a local server:
+
+```bash
+BUNNY_STORAGE_API_KEY="your-key" BUNNY_STORAGE_ZONE="your-zone" composer start
+```
+
+Then visit http://localhost:8000 in your browser.
+
+## What This Example Does
+
+1. Creates a test file in storage
+2. Verifies the file exists
+3. Deletes the file
+4. Verifies the file was deleted
+5. Demonstrates deleting multiple files at once
+6. Shows error handling for non-existent files

--- a/examples/delete-file/composer.json
+++ b/examples/delete-file/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "bunnycdn/storage-example-delete-file",
+    "description": "Delete file example for Bunny Storage SDK",
+    "type": "project",
+    "require": {
+        "php": ">=8.1",
+        "bunnycdn/storage": "*"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../"
+        }
+    ],
+    "scripts": {
+        "start": "php -S localhost:8000 index.php"
+    }
+}

--- a/examples/delete-file/index.php
+++ b/examples/delete-file/index.php
@@ -1,34 +1,32 @@
 <?php
 
-require_once __DIR__ . "/../../vendor/autoload.php";
+require_once __DIR__.'/../../vendor/autoload.php';
 
 use Bunny\Storage\Client;
 use Bunny\Storage\Region;
 
-$apiKey = getenv("BUNNY_STORAGE_API_KEY");
-$storageZone = getenv("BUNNY_STORAGE_ZONE");
-$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+$apiKey = getenv('BUNNY_STORAGE_API_KEY');
+$storageZone = getenv('BUNNY_STORAGE_ZONE');
+$region = getenv('BUNNY_STORAGE_REGION') ?: 'de';
 
 if (!$apiKey || !$storageZone) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "error" =>
-                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+            'error' => 'BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.',
         ],
         JSON_PRETTY_PRINT,
     );
     exit(1);
 }
 
-$remotePath = $argv[1] ?? ($_GET["path"] ?? null);
+$remotePath = $argv[1] ?? ($_GET['path'] ?? null);
 
 if (!$remotePath) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "error" =>
-                "No file specified. Pass a remote path as an argument or use ?path= query parameter.",
+            'error' => 'No file specified. Pass a remote path as an argument or use ?path= query parameter.',
         ],
         JSON_PRETTY_PRINT,
     );
@@ -36,15 +34,15 @@ if (!$remotePath) {
 }
 
 $regionMap = [
-    "de" => Region::FALKENSTEIN,
-    "uk" => Region::LONDON,
-    "se" => Region::STOCKHOLM,
-    "ny" => Region::NEW_YORK,
-    "la" => Region::LOS_ANGELES,
-    "sg" => Region::SINGAPORE,
-    "syd" => Region::SYDNEY,
-    "br" => Region::SAO_PAULO,
-    "jh" => Region::JOHANNESBURG,
+    'de' => Region::FALKENSTEIN,
+    'uk' => Region::LONDON,
+    'se' => Region::STOCKHOLM,
+    'ny' => Region::NEW_YORK,
+    'la' => Region::LOS_ANGELES,
+    'sg' => Region::SINGAPORE,
+    'syd' => Region::SYDNEY,
+    'br' => Region::SAO_PAULO,
+    'jh' => Region::JOHANNESBURG,
 ];
 
 $regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
@@ -54,18 +52,18 @@ try {
 
     $client->delete($remotePath);
 
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "storageZone" => $storageZone,
-            "region" => $region,
-            "path" => $remotePath,
-            "status" => "deleted",
+            'storageZone' => $storageZone,
+            'region' => $region,
+            'path' => $remotePath,
+            'status' => 'deleted',
         ],
         JSON_PRETTY_PRINT,
     );
 } catch (Exception $e) {
-    header("Content-Type: application/json");
-    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => $e->getMessage()], JSON_PRETTY_PRINT);
     exit(1);
 }

--- a/examples/delete-file/index.php
+++ b/examples/delete-file/index.php
@@ -1,0 +1,71 @@
+<?php
+
+require_once __DIR__ . "/../../vendor/autoload.php";
+
+use Bunny\Storage\Client;
+use Bunny\Storage\Region;
+
+$apiKey = getenv("BUNNY_STORAGE_API_KEY");
+$storageZone = getenv("BUNNY_STORAGE_ZONE");
+$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+
+if (!$apiKey || !$storageZone) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "error" =>
+                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+$remotePath = $argv[1] ?? ($_GET["path"] ?? null);
+
+if (!$remotePath) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "error" =>
+                "No file specified. Pass a remote path as an argument or use ?path= query parameter.",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+$regionMap = [
+    "de" => Region::FALKENSTEIN,
+    "uk" => Region::LONDON,
+    "se" => Region::STOCKHOLM,
+    "ny" => Region::NEW_YORK,
+    "la" => Region::LOS_ANGELES,
+    "sg" => Region::SINGAPORE,
+    "syd" => Region::SYDNEY,
+    "br" => Region::SAO_PAULO,
+    "jh" => Region::JOHANNESBURG,
+];
+
+$regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
+
+try {
+    $client = new Client($apiKey, $storageZone, $regionConstant);
+
+    $client->delete($remotePath);
+
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "storageZone" => $storageZone,
+            "region" => $region,
+            "path" => $remotePath,
+            "status" => "deleted",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+} catch (Exception $e) {
+    header("Content-Type: application/json");
+    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    exit(1);
+}

--- a/examples/delete-multiple-files/README.md
+++ b/examples/delete-multiple-files/README.md
@@ -1,0 +1,65 @@
+# Delete Multiple Files Example
+
+This example demonstrates how to delete multiple files at once from Bunny Storage using `deleteMultiple()`.
+
+## Prerequisites
+
+- PHP 8.1 or higher
+- Composer
+- A Bunny Storage zone with API credentials
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+composer install
+```
+
+2. Set the required environment variables:
+
+```bash
+export BUNNY_STORAGE_API_KEY="your-storage-api-key"
+export BUNNY_STORAGE_ZONE="your-storage-zone-name"
+export BUNNY_STORAGE_REGION="de"  # Optional, defaults to "de" (Falkenstein)
+```
+
+## Running the Example
+
+### CLI
+
+Pass file paths as arguments:
+
+```bash
+php index.php file1.txt file2.txt uploads/file3.txt
+```
+
+### Web Server
+
+Start a local server:
+
+```bash
+composer start
+```
+
+Then visit: http://localhost:8000?paths=file1.txt,file2.txt,uploads/file3.txt
+
+## Output
+
+Returns a JSON response with deletion results:
+
+```json
+{
+    "storageZone": "your-zone",
+    "region": "de",
+    "paths": ["file1.txt", "file2.txt", "uploads/file3.txt"],
+    "summary": {
+        "total": 3,
+        "deleted": 2,
+        "failed": 1
+    },
+    "errors": {
+        "uploads/file3.txt": "File not found"
+    }
+}
+```

--- a/examples/delete-multiple-files/composer.json
+++ b/examples/delete-multiple-files/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "bunnycdn/storage-example-delete-multiple-files",
+    "description": "Delete multiple files example for Bunny Storage SDK",
+    "type": "project",
+    "require": {
+        "php": ">=8.1",
+        "bunnycdn/storage": "*"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../"
+        }
+    ],
+    "scripts": {
+        "start": "php -S localhost:8000 index.php"
+    }
+}

--- a/examples/delete-multiple-files/index.php
+++ b/examples/delete-multiple-files/index.php
@@ -1,0 +1,87 @@
+<?php
+
+require_once __DIR__ . "/../../vendor/autoload.php";
+
+use Bunny\Storage\Client;
+use Bunny\Storage\Region;
+
+$apiKey = getenv("BUNNY_STORAGE_API_KEY");
+$storageZone = getenv("BUNNY_STORAGE_ZONE");
+$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+
+if (!$apiKey || !$storageZone) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "error" =>
+                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+$paths = [];
+
+if (php_sapi_name() === "cli") {
+    $paths = array_slice($argv, 1);
+} else {
+    $pathsParam = $_GET["paths"] ?? "";
+    if ($pathsParam) {
+        $paths = array_map("trim", explode(",", $pathsParam));
+    }
+}
+
+if (empty($paths)) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "error" =>
+                "No files specified. Pass remote paths as arguments or use ?paths=file1.txt,file2.txt query parameter.",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+$regionMap = [
+    "de" => Region::FALKENSTEIN,
+    "uk" => Region::LONDON,
+    "se" => Region::STOCKHOLM,
+    "ny" => Region::NEW_YORK,
+    "la" => Region::LOS_ANGELES,
+    "sg" => Region::SINGAPORE,
+    "syd" => Region::SYDNEY,
+    "br" => Region::SAO_PAULO,
+    "jh" => Region::JOHANNESBURG,
+];
+
+$regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
+
+try {
+    $client = new Client($apiKey, $storageZone, $regionConstant);
+
+    $errors = $client->deleteMultiple($paths);
+
+    $deleted = count($paths) - count($errors);
+
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "storageZone" => $storageZone,
+            "region" => $region,
+            "paths" => $paths,
+            "summary" => [
+                "total" => count($paths),
+                "deleted" => $deleted,
+                "failed" => count($errors),
+            ],
+            "errors" => $errors,
+        ],
+        JSON_PRETTY_PRINT,
+    );
+} catch (Exception $e) {
+    header("Content-Type: application/json");
+    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    exit(1);
+}

--- a/examples/delete-multiple-files/index.php
+++ b/examples/delete-multiple-files/index.php
@@ -1,20 +1,19 @@
 <?php
 
-require_once __DIR__ . "/../../vendor/autoload.php";
+require_once __DIR__.'/../../vendor/autoload.php';
 
 use Bunny\Storage\Client;
 use Bunny\Storage\Region;
 
-$apiKey = getenv("BUNNY_STORAGE_API_KEY");
-$storageZone = getenv("BUNNY_STORAGE_ZONE");
-$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+$apiKey = getenv('BUNNY_STORAGE_API_KEY');
+$storageZone = getenv('BUNNY_STORAGE_ZONE');
+$region = getenv('BUNNY_STORAGE_REGION') ?: 'de';
 
 if (!$apiKey || !$storageZone) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "error" =>
-                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+            'error' => 'BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.',
         ],
         JSON_PRETTY_PRINT,
     );
@@ -23,21 +22,20 @@ if (!$apiKey || !$storageZone) {
 
 $paths = [];
 
-if (php_sapi_name() === "cli") {
+if ('cli' === php_sapi_name()) {
     $paths = array_slice($argv, 1);
 } else {
-    $pathsParam = $_GET["paths"] ?? "";
+    $pathsParam = $_GET['paths'] ?? '';
     if ($pathsParam) {
-        $paths = array_map("trim", explode(",", $pathsParam));
+        $paths = array_map('trim', explode(',', $pathsParam));
     }
 }
 
 if (empty($paths)) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "error" =>
-                "No files specified. Pass remote paths as arguments or use ?paths=file1.txt,file2.txt query parameter.",
+            'error' => 'No files specified. Pass remote paths as arguments or use ?paths=file1.txt,file2.txt query parameter.',
         ],
         JSON_PRETTY_PRINT,
     );
@@ -45,15 +43,15 @@ if (empty($paths)) {
 }
 
 $regionMap = [
-    "de" => Region::FALKENSTEIN,
-    "uk" => Region::LONDON,
-    "se" => Region::STOCKHOLM,
-    "ny" => Region::NEW_YORK,
-    "la" => Region::LOS_ANGELES,
-    "sg" => Region::SINGAPORE,
-    "syd" => Region::SYDNEY,
-    "br" => Region::SAO_PAULO,
-    "jh" => Region::JOHANNESBURG,
+    'de' => Region::FALKENSTEIN,
+    'uk' => Region::LONDON,
+    'se' => Region::STOCKHOLM,
+    'ny' => Region::NEW_YORK,
+    'la' => Region::LOS_ANGELES,
+    'sg' => Region::SINGAPORE,
+    'syd' => Region::SYDNEY,
+    'br' => Region::SAO_PAULO,
+    'jh' => Region::JOHANNESBURG,
 ];
 
 $regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
@@ -65,23 +63,23 @@ try {
 
     $deleted = count($paths) - count($errors);
 
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "storageZone" => $storageZone,
-            "region" => $region,
-            "paths" => $paths,
-            "summary" => [
-                "total" => count($paths),
-                "deleted" => $deleted,
-                "failed" => count($errors),
+            'storageZone' => $storageZone,
+            'region' => $region,
+            'paths' => $paths,
+            'summary' => [
+                'total' => count($paths),
+                'deleted' => $deleted,
+                'failed' => count($errors),
             ],
-            "errors" => $errors,
+            'errors' => $errors,
         ],
         JSON_PRETTY_PRINT,
     );
 } catch (Exception $e) {
-    header("Content-Type: application/json");
-    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => $e->getMessage()], JSON_PRETTY_PRINT);
     exit(1);
 }

--- a/examples/delete-old-files/README.md
+++ b/examples/delete-old-files/README.md
@@ -1,0 +1,71 @@
+# Delete Old Files Example
+
+This example demonstrates how to find and delete files older than a specified age from Bunny Storage.
+
+## Prerequisites
+
+- PHP 8.1 or higher
+- Composer
+- A Bunny Storage zone with API credentials
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+composer install
+```
+
+2. Set the required environment variables:
+
+```bash
+export BUNNY_STORAGE_API_KEY="your-storage-api-key"
+export BUNNY_STORAGE_ZONE="your-storage-zone-name"
+export BUNNY_STORAGE_REGION="de"  # Optional, defaults to "de" (Falkenstein)
+```
+
+## Running the Example
+
+Run directly with PHP:
+
+```bash
+BUNNY_STORAGE_API_KEY="your-key" BUNNY_STORAGE_ZONE="your-zone" php index.php
+```
+
+Or start a local server:
+
+```bash
+BUNNY_STORAGE_API_KEY="your-key" BUNNY_STORAGE_ZONE="your-zone" composer start
+```
+
+Then visit http://localhost:8000 in your browser.
+
+## Configuration
+
+You can customize the behavior by setting additional environment variables:
+
+```bash
+# Directory to scan (default: root)
+export BUNNY_SCAN_PATH="/"
+
+# Maximum age in days (default: 30)
+export BUNNY_MAX_AGE_DAYS="30"
+
+# Dry run mode - don't actually delete (default: true)
+export BUNNY_DRY_RUN="true"
+```
+
+## What This Example Does
+
+1. Lists all files in the specified directory
+2. Identifies files older than the specified age
+3. In dry run mode: shows what would be deleted
+4. In live mode: deletes old files using batch deletion
+5. Reports results including any errors
+
+## Use Cases
+
+- Cleaning up temporary files
+- Removing old log files
+- Managing storage costs by removing outdated content
+- Automated maintenance scripts (via cron)

--- a/examples/delete-old-files/composer.json
+++ b/examples/delete-old-files/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "bunnycdn/storage-example-delete-old-files",
+    "description": "Delete old files example for Bunny Storage SDK",
+    "type": "project",
+    "require": {
+        "php": ">=8.1",
+        "bunnycdn/storage": "*"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../"
+        }
+    ],
+    "scripts": {
+        "start": "php -S localhost:8000 index.php"
+    }
+}

--- a/examples/delete-old-files/index.php
+++ b/examples/delete-old-files/index.php
@@ -1,23 +1,22 @@
 <?php
 
-require_once __DIR__ . "/../../vendor/autoload.php";
+require_once __DIR__.'/../../vendor/autoload.php';
 
 use Bunny\Storage\Client;
 use Bunny\Storage\Region;
 
-$apiKey = getenv("BUNNY_STORAGE_API_KEY");
-$storageZone = getenv("BUNNY_STORAGE_ZONE");
-$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
-$scanPath = getenv("BUNNY_SCAN_PATH") ?: "/";
-$maxAgeDays = (int) (getenv("BUNNY_MAX_AGE_DAYS") ?: 30);
-$dryRun = getenv("BUNNY_DRY_RUN") !== "false";
+$apiKey = getenv('BUNNY_STORAGE_API_KEY');
+$storageZone = getenv('BUNNY_STORAGE_ZONE');
+$region = getenv('BUNNY_STORAGE_REGION') ?: 'de';
+$scanPath = getenv('BUNNY_SCAN_PATH') ?: '/';
+$maxAgeDays = (int) (getenv('BUNNY_MAX_AGE_DAYS') ?: 30);
+$dryRun = 'false' !== getenv('BUNNY_DRY_RUN');
 
 if (!$apiKey || !$storageZone) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "error" =>
-                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+            'error' => 'BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.',
         ],
         JSON_PRETTY_PRINT,
     );
@@ -25,15 +24,15 @@ if (!$apiKey || !$storageZone) {
 }
 
 $regionMap = [
-    "de" => Region::FALKENSTEIN,
-    "uk" => Region::LONDON,
-    "se" => Region::STOCKHOLM,
-    "ny" => Region::NEW_YORK,
-    "la" => Region::LOS_ANGELES,
-    "sg" => Region::SINGAPORE,
-    "syd" => Region::SYDNEY,
-    "br" => Region::SAO_PAULO,
-    "jh" => Region::JOHANNESBURG,
+    'de' => Region::FALKENSTEIN,
+    'uk' => Region::LONDON,
+    'se' => Region::STOCKHOLM,
+    'ny' => Region::NEW_YORK,
+    'la' => Region::LOS_ANGELES,
+    'sg' => Region::SINGAPORE,
+    'syd' => Region::SYDNEY,
+    'br' => Region::SAO_PAULO,
+    'jh' => Region::JOHANNESBURG,
 ];
 
 $regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
@@ -46,15 +45,15 @@ try {
     $files = $client->listFiles($scanPath);
 
     if (empty($files)) {
-        header("Content-Type: application/json");
+        header('Content-Type: application/json');
         echo json_encode(
             [
-                "storageZone" => $storageZone,
-                "region" => $region,
-                "scanPath" => $scanPath,
-                "maxAgeDays" => $maxAgeDays,
-                "dryRun" => $dryRun,
-                "message" => "No files found in '{$scanPath}'",
+                'storageZone' => $storageZone,
+                'region' => $region,
+                'scanPath' => $scanPath,
+                'maxAgeDays' => $maxAgeDays,
+                'dryRun' => $dryRun,
+                'message' => "No files found in '{$scanPath}'",
             ],
             JSON_PRETTY_PRINT,
         );
@@ -71,7 +70,7 @@ try {
             continue;
         }
 
-        $totalFiles++;
+        ++$totalFiles;
         $totalSize += $file->getSize();
 
         if ($file->getDateModified() < $cutoffDate) {
@@ -81,50 +80,50 @@ try {
     }
 
     $filesToDelete = array_map(
-        fn($file) => [
-            "name" => $file->getName(),
-            "size" => $file->getSize(),
-            "dateModified" => $file->getDateModified()->format("c"),
-            "ageDays" => $file->getDateModified()->diff(new DateTimeImmutable())
+        fn ($file) => [
+            'name' => $file->getName(),
+            'size' => $file->getSize(),
+            'dateModified' => $file->getDateModified()->format('c'),
+            'ageDays' => $file->getDateModified()->diff(new DateTimeImmutable())
                 ->days,
         ],
         $oldFiles,
     );
 
     $response = [
-        "storageZone" => $storageZone,
-        "region" => $region,
-        "scanPath" => $scanPath,
-        "maxAgeDays" => $maxAgeDays,
-        "cutoffDate" => $cutoffDate->format("c"),
-        "dryRun" => $dryRun,
-        "summary" => [
-            "totalFiles" => $totalFiles,
-            "totalSize" => $totalSize,
-            "oldFilesCount" => count($oldFiles),
-            "oldFilesSize" => $oldSize,
+        'storageZone' => $storageZone,
+        'region' => $region,
+        'scanPath' => $scanPath,
+        'maxAgeDays' => $maxAgeDays,
+        'cutoffDate' => $cutoffDate->format('c'),
+        'dryRun' => $dryRun,
+        'summary' => [
+            'totalFiles' => $totalFiles,
+            'totalSize' => $totalSize,
+            'oldFilesCount' => count($oldFiles),
+            'oldFilesSize' => $oldSize,
         ],
-        "filesToDelete" => $filesToDelete,
+        'filesToDelete' => $filesToDelete,
     ];
 
     if (!$dryRun && !empty($oldFiles)) {
-        $fileNames = array_map(fn($file) => $file->getName(), $oldFiles);
+        $fileNames = array_map(fn ($file) => $file->getName(), $oldFiles);
         $errors = $client->deleteMultiple($fileNames);
 
         $deleted = count($oldFiles) - count($errors);
 
-        $response["deletionResult"] = [
-            "deleted" => $deleted,
-            "failed" => count($errors),
-            "spaceFreed" => $oldSize,
-            "errors" => $errors,
+        $response['deletionResult'] = [
+            'deleted' => $deleted,
+            'failed' => count($errors),
+            'spaceFreed' => $oldSize,
+            'errors' => $errors,
         ];
     }
 
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode($response, JSON_PRETTY_PRINT);
 } catch (Exception $e) {
-    header("Content-Type: application/json");
-    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => $e->getMessage()], JSON_PRETTY_PRINT);
     exit(1);
 }

--- a/examples/delete-old-files/index.php
+++ b/examples/delete-old-files/index.php
@@ -1,0 +1,130 @@
+<?php
+
+require_once __DIR__ . "/../../vendor/autoload.php";
+
+use Bunny\Storage\Client;
+use Bunny\Storage\Region;
+
+$apiKey = getenv("BUNNY_STORAGE_API_KEY");
+$storageZone = getenv("BUNNY_STORAGE_ZONE");
+$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+$scanPath = getenv("BUNNY_SCAN_PATH") ?: "/";
+$maxAgeDays = (int) (getenv("BUNNY_MAX_AGE_DAYS") ?: 30);
+$dryRun = getenv("BUNNY_DRY_RUN") !== "false";
+
+if (!$apiKey || !$storageZone) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "error" =>
+                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+$regionMap = [
+    "de" => Region::FALKENSTEIN,
+    "uk" => Region::LONDON,
+    "se" => Region::STOCKHOLM,
+    "ny" => Region::NEW_YORK,
+    "la" => Region::LOS_ANGELES,
+    "sg" => Region::SINGAPORE,
+    "syd" => Region::SYDNEY,
+    "br" => Region::SAO_PAULO,
+    "jh" => Region::JOHANNESBURG,
+];
+
+$regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
+
+try {
+    $client = new Client($apiKey, $storageZone, $regionConstant);
+
+    $cutoffDate = new DateTimeImmutable("-{$maxAgeDays} days");
+
+    $files = $client->listFiles($scanPath);
+
+    if (empty($files)) {
+        header("Content-Type: application/json");
+        echo json_encode(
+            [
+                "storageZone" => $storageZone,
+                "region" => $region,
+                "scanPath" => $scanPath,
+                "maxAgeDays" => $maxAgeDays,
+                "dryRun" => $dryRun,
+                "message" => "No files found in '{$scanPath}'",
+            ],
+            JSON_PRETTY_PRINT,
+        );
+        exit(0);
+    }
+
+    $oldFiles = [];
+    $totalFiles = 0;
+    $totalSize = 0;
+    $oldSize = 0;
+
+    foreach ($files as $file) {
+        if ($file->isDirectory()) {
+            continue;
+        }
+
+        $totalFiles++;
+        $totalSize += $file->getSize();
+
+        if ($file->getDateModified() < $cutoffDate) {
+            $oldFiles[] = $file;
+            $oldSize += $file->getSize();
+        }
+    }
+
+    $filesToDelete = array_map(
+        fn($file) => [
+            "name" => $file->getName(),
+            "size" => $file->getSize(),
+            "dateModified" => $file->getDateModified()->format("c"),
+            "ageDays" => $file->getDateModified()->diff(new DateTimeImmutable())
+                ->days,
+        ],
+        $oldFiles,
+    );
+
+    $response = [
+        "storageZone" => $storageZone,
+        "region" => $region,
+        "scanPath" => $scanPath,
+        "maxAgeDays" => $maxAgeDays,
+        "cutoffDate" => $cutoffDate->format("c"),
+        "dryRun" => $dryRun,
+        "summary" => [
+            "totalFiles" => $totalFiles,
+            "totalSize" => $totalSize,
+            "oldFilesCount" => count($oldFiles),
+            "oldFilesSize" => $oldSize,
+        ],
+        "filesToDelete" => $filesToDelete,
+    ];
+
+    if (!$dryRun && !empty($oldFiles)) {
+        $fileNames = array_map(fn($file) => $file->getName(), $oldFiles);
+        $errors = $client->deleteMultiple($fileNames);
+
+        $deleted = count($oldFiles) - count($errors);
+
+        $response["deletionResult"] = [
+            "deleted" => $deleted,
+            "failed" => count($errors),
+            "spaceFreed" => $oldSize,
+            "errors" => $errors,
+        ];
+    }
+
+    header("Content-Type: application/json");
+    echo json_encode($response, JSON_PRETTY_PRINT);
+} catch (Exception $e) {
+    header("Content-Type: application/json");
+    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    exit(1);
+}

--- a/examples/download-file/README.md
+++ b/examples/download-file/README.md
@@ -1,0 +1,70 @@
+# Download File Example
+
+This example demonstrates how to download a file from Bunny Storage to your local filesystem.
+
+## Prerequisites
+
+- PHP 8.1 or higher
+- Composer
+- A Bunny Storage zone with API credentials
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+composer install
+```
+
+2. Set the required environment variables:
+
+```bash
+export BUNNY_STORAGE_API_KEY="your-storage-api-key"
+export BUNNY_STORAGE_ZONE="your-storage-zone-name"
+export BUNNY_STORAGE_REGION="de"  # Optional, defaults to "de" (Falkenstein)
+```
+
+## Running the Example
+
+### CLI
+
+Download a file (saves to `downloads/` directory by default):
+
+```bash
+php index.php remote/path/file.txt
+```
+
+Specify a custom local path:
+
+```bash
+php index.php remote/path/file.txt /path/to/local/file.txt
+```
+
+### Web Server
+
+Start a local server:
+
+```bash
+composer start
+```
+
+Then visit: http://localhost:8000?path=remote/path/file.txt
+
+Or with a custom local path: http://localhost:8000?path=remote/path/file.txt&localPath=/tmp/file.txt
+
+## Output
+
+Returns a JSON response with download details:
+
+```json
+{
+    "storageZone": "your-zone",
+    "region": "de",
+    "file": {
+        "remotePath": "remote/path/file.txt",
+        "localPath": "/path/to/downloads/file.txt",
+        "size": 1234
+    },
+    "status": "success"
+}
+```

--- a/examples/download-file/composer.json
+++ b/examples/download-file/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "bunnycdn/storage-example-download-file",
+    "description": "Download file example for Bunny Storage SDK",
+    "type": "project",
+    "require": {
+        "php": ">=8.1",
+        "bunnycdn/storage": "*"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../"
+        }
+    ],
+    "scripts": {
+        "start": "php -S localhost:8000 index.php"
+    }
+}

--- a/examples/download-file/index.php
+++ b/examples/download-file/index.php
@@ -1,0 +1,85 @@
+<?php
+
+require_once __DIR__ . "/../../vendor/autoload.php";
+
+use Bunny\Storage\Client;
+use Bunny\Storage\Region;
+
+$apiKey = getenv("BUNNY_STORAGE_API_KEY");
+$storageZone = getenv("BUNNY_STORAGE_ZONE");
+$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+
+if (!$apiKey || !$storageZone) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "error" =>
+                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+$remotePath = $argv[1] ?? ($_GET["path"] ?? null);
+$localPath = $argv[2] ?? ($_GET["localPath"] ?? null);
+
+if (!$remotePath) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "error" =>
+                "No file specified. Pass a remote path as an argument or use ?path= query parameter.",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+if (!$localPath) {
+    $localPath = __DIR__ . "/downloads/" . basename($remotePath);
+}
+
+$downloadDir = dirname($localPath);
+if (!is_dir($downloadDir)) {
+    mkdir($downloadDir, 0755, true);
+}
+
+$regionMap = [
+    "de" => Region::FALKENSTEIN,
+    "uk" => Region::LONDON,
+    "se" => Region::STOCKHOLM,
+    "ny" => Region::NEW_YORK,
+    "la" => Region::LOS_ANGELES,
+    "sg" => Region::SINGAPORE,
+    "syd" => Region::SYDNEY,
+    "br" => Region::SAO_PAULO,
+    "jh" => Region::JOHANNESBURG,
+];
+
+$regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
+
+try {
+    $client = new Client($apiKey, $storageZone, $regionConstant);
+
+    $client->download($remotePath, $localPath);
+
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "storageZone" => $storageZone,
+            "region" => $region,
+            "file" => [
+                "remotePath" => $remotePath,
+                "localPath" => $localPath,
+                "size" => filesize($localPath),
+            ],
+            "status" => "success",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+} catch (Exception $e) {
+    header("Content-Type: application/json");
+    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    exit(1);
+}

--- a/examples/download-file/index.php
+++ b/examples/download-file/index.php
@@ -1,35 +1,33 @@
 <?php
 
-require_once __DIR__ . "/../../vendor/autoload.php";
+require_once __DIR__.'/../../vendor/autoload.php';
 
 use Bunny\Storage\Client;
 use Bunny\Storage\Region;
 
-$apiKey = getenv("BUNNY_STORAGE_API_KEY");
-$storageZone = getenv("BUNNY_STORAGE_ZONE");
-$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+$apiKey = getenv('BUNNY_STORAGE_API_KEY');
+$storageZone = getenv('BUNNY_STORAGE_ZONE');
+$region = getenv('BUNNY_STORAGE_REGION') ?: 'de';
 
 if (!$apiKey || !$storageZone) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "error" =>
-                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+            'error' => 'BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.',
         ],
         JSON_PRETTY_PRINT,
     );
     exit(1);
 }
 
-$remotePath = $argv[1] ?? ($_GET["path"] ?? null);
-$localPath = $argv[2] ?? ($_GET["localPath"] ?? null);
+$remotePath = $argv[1] ?? ($_GET['path'] ?? null);
+$localPath = $argv[2] ?? ($_GET['localPath'] ?? null);
 
 if (!$remotePath) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "error" =>
-                "No file specified. Pass a remote path as an argument or use ?path= query parameter.",
+            'error' => 'No file specified. Pass a remote path as an argument or use ?path= query parameter.',
         ],
         JSON_PRETTY_PRINT,
     );
@@ -37,7 +35,7 @@ if (!$remotePath) {
 }
 
 if (!$localPath) {
-    $localPath = __DIR__ . "/downloads/" . basename($remotePath);
+    $localPath = __DIR__.'/downloads/'.basename($remotePath);
 }
 
 $downloadDir = dirname($localPath);
@@ -46,15 +44,15 @@ if (!is_dir($downloadDir)) {
 }
 
 $regionMap = [
-    "de" => Region::FALKENSTEIN,
-    "uk" => Region::LONDON,
-    "se" => Region::STOCKHOLM,
-    "ny" => Region::NEW_YORK,
-    "la" => Region::LOS_ANGELES,
-    "sg" => Region::SINGAPORE,
-    "syd" => Region::SYDNEY,
-    "br" => Region::SAO_PAULO,
-    "jh" => Region::JOHANNESBURG,
+    'de' => Region::FALKENSTEIN,
+    'uk' => Region::LONDON,
+    'se' => Region::STOCKHOLM,
+    'ny' => Region::NEW_YORK,
+    'la' => Region::LOS_ANGELES,
+    'sg' => Region::SINGAPORE,
+    'syd' => Region::SYDNEY,
+    'br' => Region::SAO_PAULO,
+    'jh' => Region::JOHANNESBURG,
 ];
 
 $regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
@@ -64,22 +62,22 @@ try {
 
     $client->download($remotePath, $localPath);
 
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "storageZone" => $storageZone,
-            "region" => $region,
-            "file" => [
-                "remotePath" => $remotePath,
-                "localPath" => $localPath,
-                "size" => filesize($localPath),
+            'storageZone' => $storageZone,
+            'region' => $region,
+            'file' => [
+                'remotePath' => $remotePath,
+                'localPath' => $localPath,
+                'size' => filesize($localPath),
             ],
-            "status" => "success",
+            'status' => 'success',
         ],
         JSON_PRETTY_PRINT,
     );
 } catch (Exception $e) {
-    header("Content-Type: application/json");
-    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => $e->getMessage()], JSON_PRETTY_PRINT);
     exit(1);
 }

--- a/examples/file-info/README.md
+++ b/examples/file-info/README.md
@@ -1,0 +1,64 @@
+# File Info Example
+
+This example demonstrates how to get metadata and details about a file in Bunny Storage.
+
+## Prerequisites
+
+- PHP 8.1 or higher
+- Composer
+- A Bunny Storage zone with API credentials
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+composer install
+```
+
+2. Set the required environment variables:
+
+```bash
+export BUNNY_STORAGE_API_KEY="your-storage-api-key"
+export BUNNY_STORAGE_ZONE="your-storage-zone-name"
+export BUNNY_STORAGE_REGION="de"  # Optional, defaults to "de" (Falkenstein)
+```
+
+## Running the Example
+
+### CLI
+
+```bash
+php index.php remote/path/file.txt
+```
+
+### Web Server
+
+Start a local server:
+
+```bash
+composer start
+```
+
+Then visit: http://localhost:8000?path=remote/path/file.txt
+
+## Output
+
+Returns a JSON response with file metadata:
+
+```json
+{
+    "storageZone": "your-zone",
+    "region": "de",
+    "file": {
+        "path": "remote/path/file.txt",
+        "name": "file.txt",
+        "size": 1234,
+        "isDirectory": false,
+        "dateModified": "2024-01-15T10:30:00+00:00",
+        "dateCreated": "2024-01-10T08:00:00+00:00",
+        "checksum": "abc123...",
+        "contentType": "text/plain"
+    }
+}
+```

--- a/examples/file-info/composer.json
+++ b/examples/file-info/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "bunnycdn/storage-example-file-info",
+    "description": "File info example for Bunny Storage SDK",
+    "type": "project",
+    "require": {
+        "php": ">=8.1",
+        "bunnycdn/storage": "*"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../"
+        }
+    ],
+    "scripts": {
+        "start": "php -S localhost:8000 index.php"
+    }
+}

--- a/examples/file-info/index.php
+++ b/examples/file-info/index.php
@@ -1,0 +1,78 @@
+<?php
+
+require_once __DIR__ . "/../../vendor/autoload.php";
+
+use Bunny\Storage\Client;
+use Bunny\Storage\Region;
+
+$apiKey = getenv("BUNNY_STORAGE_API_KEY");
+$storageZone = getenv("BUNNY_STORAGE_ZONE");
+$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+
+if (!$apiKey || !$storageZone) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "error" =>
+                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+$remotePath = $argv[1] ?? ($_GET["path"] ?? null);
+
+if (!$remotePath) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "error" =>
+                "No file specified. Pass a remote path as an argument or use ?path= query parameter.",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+$regionMap = [
+    "de" => Region::FALKENSTEIN,
+    "uk" => Region::LONDON,
+    "se" => Region::STOCKHOLM,
+    "ny" => Region::NEW_YORK,
+    "la" => Region::LOS_ANGELES,
+    "sg" => Region::SINGAPORE,
+    "syd" => Region::SYDNEY,
+    "br" => Region::SAO_PAULO,
+    "jh" => Region::JOHANNESBURG,
+];
+
+$regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
+
+try {
+    $client = new Client($apiKey, $storageZone, $regionConstant);
+
+    $file = $client->info($remotePath);
+
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "storageZone" => $storageZone,
+            "region" => $region,
+            "file" => [
+                "path" => $remotePath,
+                "name" => $file->getName(),
+                "size" => $file->getSize(),
+                "isDirectory" => $file->isDirectory(),
+                "dateModified" => $file->getDateModified()->format("c"),
+                "dateCreated" => $file->getDateCreated()->format("c"),
+                "checksum" => $file->getChecksum(),
+            ],
+        ],
+        JSON_PRETTY_PRINT,
+    );
+} catch (Exception $e) {
+    header("Content-Type: application/json");
+    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    exit(1);
+}

--- a/examples/file-info/index.php
+++ b/examples/file-info/index.php
@@ -1,34 +1,32 @@
 <?php
 
-require_once __DIR__ . "/../../vendor/autoload.php";
+require_once __DIR__.'/../../vendor/autoload.php';
 
 use Bunny\Storage\Client;
 use Bunny\Storage\Region;
 
-$apiKey = getenv("BUNNY_STORAGE_API_KEY");
-$storageZone = getenv("BUNNY_STORAGE_ZONE");
-$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+$apiKey = getenv('BUNNY_STORAGE_API_KEY');
+$storageZone = getenv('BUNNY_STORAGE_ZONE');
+$region = getenv('BUNNY_STORAGE_REGION') ?: 'de';
 
 if (!$apiKey || !$storageZone) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "error" =>
-                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+            'error' => 'BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.',
         ],
         JSON_PRETTY_PRINT,
     );
     exit(1);
 }
 
-$remotePath = $argv[1] ?? ($_GET["path"] ?? null);
+$remotePath = $argv[1] ?? ($_GET['path'] ?? null);
 
 if (!$remotePath) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "error" =>
-                "No file specified. Pass a remote path as an argument or use ?path= query parameter.",
+            'error' => 'No file specified. Pass a remote path as an argument or use ?path= query parameter.',
         ],
         JSON_PRETTY_PRINT,
     );
@@ -36,15 +34,15 @@ if (!$remotePath) {
 }
 
 $regionMap = [
-    "de" => Region::FALKENSTEIN,
-    "uk" => Region::LONDON,
-    "se" => Region::STOCKHOLM,
-    "ny" => Region::NEW_YORK,
-    "la" => Region::LOS_ANGELES,
-    "sg" => Region::SINGAPORE,
-    "syd" => Region::SYDNEY,
-    "br" => Region::SAO_PAULO,
-    "jh" => Region::JOHANNESBURG,
+    'de' => Region::FALKENSTEIN,
+    'uk' => Region::LONDON,
+    'se' => Region::STOCKHOLM,
+    'ny' => Region::NEW_YORK,
+    'la' => Region::LOS_ANGELES,
+    'sg' => Region::SINGAPORE,
+    'syd' => Region::SYDNEY,
+    'br' => Region::SAO_PAULO,
+    'jh' => Region::JOHANNESBURG,
 ];
 
 $regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
@@ -54,25 +52,25 @@ try {
 
     $file = $client->info($remotePath);
 
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "storageZone" => $storageZone,
-            "region" => $region,
-            "file" => [
-                "path" => $remotePath,
-                "name" => $file->getName(),
-                "size" => $file->getSize(),
-                "isDirectory" => $file->isDirectory(),
-                "dateModified" => $file->getDateModified()->format("c"),
-                "dateCreated" => $file->getDateCreated()->format("c"),
-                "checksum" => $file->getChecksum(),
+            'storageZone' => $storageZone,
+            'region' => $region,
+            'file' => [
+                'path' => $remotePath,
+                'name' => $file->getName(),
+                'size' => $file->getSize(),
+                'isDirectory' => $file->isDirectory(),
+                'dateModified' => $file->getDateModified()->format('c'),
+                'dateCreated' => $file->getDateCreated()->format('c'),
+                'checksum' => $file->getChecksum(),
             ],
         ],
         JSON_PRETTY_PRINT,
     );
 } catch (Exception $e) {
-    header("Content-Type: application/json");
-    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => $e->getMessage()], JSON_PRETTY_PRINT);
     exit(1);
 }

--- a/examples/file-upload/README.md
+++ b/examples/file-upload/README.md
@@ -1,0 +1,70 @@
+# File Upload Example
+
+This example demonstrates how to upload a single file from your local filesystem to Bunny Storage.
+
+## Prerequisites
+
+- PHP 8.1 or higher
+- Composer
+- A Bunny Storage zone with API credentials
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+composer install
+```
+
+2. Set the required environment variables:
+
+```bash
+export BUNNY_STORAGE_API_KEY="your-storage-api-key"
+export BUNNY_STORAGE_ZONE="your-storage-zone-name"
+export BUNNY_STORAGE_REGION="de"  # Optional, defaults to "de" (Falkenstein)
+```
+
+## Running the Example
+
+### CLI
+
+Upload a file (saves to `uploads/` directory by default):
+
+```bash
+php index.php /path/to/local/file.txt
+```
+
+Specify a custom remote path:
+
+```bash
+php index.php /path/to/local/file.txt custom/remote/path.txt
+```
+
+### Web Server
+
+Start a local server:
+
+```bash
+composer start
+```
+
+Then visit: http://localhost:8000?file=/path/to/local/file.txt
+
+Or with a custom remote path: http://localhost:8000?file=/path/to/local/file.txt&remotePath=custom/path.txt
+
+## Output
+
+Returns a JSON response with upload details:
+
+```json
+{
+  "storageZone": "your-zone",
+  "region": "de",
+  "file": {
+    "localPath": "/path/to/local/file.txt",
+    "remotePath": "uploads/file.txt",
+    "size": 1234
+  },
+  "status": "success"
+}
+```

--- a/examples/file-upload/composer.json
+++ b/examples/file-upload/composer.json
@@ -1,0 +1,18 @@
+{
+  "name": "bunnycdn/storage-example-file-upload",
+  "description": "File upload form example for Bunny Storage SDK",
+  "type": "project",
+  "require": {
+    "php": ">=8.1",
+    "bunnycdn/storage": "*"
+  },
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../../"
+    }
+  ],
+  "scripts": {
+    "start": "php -S localhost:8000 index.php"
+  }
+}

--- a/examples/file-upload/index.php
+++ b/examples/file-upload/index.php
@@ -1,0 +1,96 @@
+<?php
+
+require_once __DIR__ . "/../../vendor/autoload.php";
+
+use Bunny\Storage\Client;
+use Bunny\Storage\Region;
+
+$apiKey = getenv("BUNNY_STORAGE_API_KEY");
+$storageZone = getenv("BUNNY_STORAGE_ZONE");
+$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+
+if (!$apiKey || !$storageZone) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "error" =>
+                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+$localFile = $argv[1] ?? ($_GET["file"] ?? null);
+
+if (!$localFile) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "error" =>
+                "No file specified. Pass a file path as an argument or use ?file= query parameter.",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+if (!file_exists($localFile)) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        ["error" => "File not found: {$localFile}"],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+if (!is_file($localFile)) {
+    header("Content-Type: application/json");
+    echo json_encode(
+        ["error" => "Path is not a file: {$localFile}"],
+        JSON_PRETTY_PRINT,
+    );
+    exit(1);
+}
+
+$regionMap = [
+    "de" => Region::FALKENSTEIN,
+    "uk" => Region::LONDON,
+    "se" => Region::STOCKHOLM,
+    "ny" => Region::NEW_YORK,
+    "la" => Region::LOS_ANGELES,
+    "sg" => Region::SINGAPORE,
+    "syd" => Region::SYDNEY,
+    "br" => Region::SAO_PAULO,
+    "jh" => Region::JOHANNESBURG,
+];
+
+$regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
+
+try {
+    $client = new Client($apiKey, $storageZone, $regionConstant);
+
+    $fileName = basename($localFile);
+    $remotePath = $argv[2] ?? ($_GET["remotePath"] ?? "uploads/{$fileName}");
+
+    $client->upload($localFile, $remotePath);
+
+    header("Content-Type: application/json");
+    echo json_encode(
+        [
+            "storageZone" => $storageZone,
+            "region" => $region,
+            "file" => [
+                "localPath" => $localFile,
+                "remotePath" => $remotePath,
+                "size" => filesize($localFile),
+            ],
+            "status" => "success",
+        ],
+        JSON_PRETTY_PRINT,
+    );
+} catch (Exception $e) {
+    header("Content-Type: application/json");
+    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    exit(1);
+}

--- a/examples/file-upload/index.php
+++ b/examples/file-upload/index.php
@@ -1,34 +1,32 @@
 <?php
 
-require_once __DIR__ . "/../../vendor/autoload.php";
+require_once __DIR__.'/../../vendor/autoload.php';
 
 use Bunny\Storage\Client;
 use Bunny\Storage\Region;
 
-$apiKey = getenv("BUNNY_STORAGE_API_KEY");
-$storageZone = getenv("BUNNY_STORAGE_ZONE");
-$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+$apiKey = getenv('BUNNY_STORAGE_API_KEY');
+$storageZone = getenv('BUNNY_STORAGE_ZONE');
+$region = getenv('BUNNY_STORAGE_REGION') ?: 'de';
 
 if (!$apiKey || !$storageZone) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "error" =>
-                "BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.",
+            'error' => 'BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.',
         ],
         JSON_PRETTY_PRINT,
     );
     exit(1);
 }
 
-$localFile = $argv[1] ?? ($_GET["file"] ?? null);
+$localFile = $argv[1] ?? ($_GET['file'] ?? null);
 
 if (!$localFile) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "error" =>
-                "No file specified. Pass a file path as an argument or use ?file= query parameter.",
+            'error' => 'No file specified. Pass a file path as an argument or use ?file= query parameter.',
         ],
         JSON_PRETTY_PRINT,
     );
@@ -36,33 +34,33 @@ if (!$localFile) {
 }
 
 if (!file_exists($localFile)) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
-        ["error" => "File not found: {$localFile}"],
+        ['error' => "File not found: {$localFile}"],
         JSON_PRETTY_PRINT,
     );
     exit(1);
 }
 
 if (!is_file($localFile)) {
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
-        ["error" => "Path is not a file: {$localFile}"],
+        ['error' => "Path is not a file: {$localFile}"],
         JSON_PRETTY_PRINT,
     );
     exit(1);
 }
 
 $regionMap = [
-    "de" => Region::FALKENSTEIN,
-    "uk" => Region::LONDON,
-    "se" => Region::STOCKHOLM,
-    "ny" => Region::NEW_YORK,
-    "la" => Region::LOS_ANGELES,
-    "sg" => Region::SINGAPORE,
-    "syd" => Region::SYDNEY,
-    "br" => Region::SAO_PAULO,
-    "jh" => Region::JOHANNESBURG,
+    'de' => Region::FALKENSTEIN,
+    'uk' => Region::LONDON,
+    'se' => Region::STOCKHOLM,
+    'ny' => Region::NEW_YORK,
+    'la' => Region::LOS_ANGELES,
+    'sg' => Region::SINGAPORE,
+    'syd' => Region::SYDNEY,
+    'br' => Region::SAO_PAULO,
+    'jh' => Region::JOHANNESBURG,
 ];
 
 $regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
@@ -71,26 +69,26 @@ try {
     $client = new Client($apiKey, $storageZone, $regionConstant);
 
     $fileName = basename($localFile);
-    $remotePath = $argv[2] ?? ($_GET["remotePath"] ?? "uploads/{$fileName}");
+    $remotePath = $argv[2] ?? ($_GET['remotePath'] ?? "uploads/{$fileName}");
 
     $client->upload($localFile, $remotePath);
 
-    header("Content-Type: application/json");
+    header('Content-Type: application/json');
     echo json_encode(
         [
-            "storageZone" => $storageZone,
-            "region" => $region,
-            "file" => [
-                "localPath" => $localFile,
-                "remotePath" => $remotePath,
-                "size" => filesize($localFile),
+            'storageZone' => $storageZone,
+            'region' => $region,
+            'file' => [
+                'localPath' => $localFile,
+                'remotePath' => $remotePath,
+                'size' => filesize($localFile),
             ],
-            "status" => "success",
+            'status' => 'success',
         ],
         JSON_PRETTY_PRINT,
     );
 } catch (Exception $e) {
-    header("Content-Type: application/json");
-    echo json_encode(["error" => $e->getMessage()], JSON_PRETTY_PRINT);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => $e->getMessage()], JSON_PRETTY_PRINT);
     exit(1);
 }

--- a/examples/form-upload/README.md
+++ b/examples/form-upload/README.md
@@ -1,0 +1,43 @@
+# File Upload Example
+
+This example demonstrates how to handle file uploads from an HTML form and store them in Bunny Storage.
+
+## Prerequisites
+
+- PHP 8.1 or higher
+- Composer
+- A Bunny Storage zone with API credentials
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+composer install
+```
+
+2. Set the required environment variables:
+
+```bash
+export BUNNY_STORAGE_API_KEY="your-storage-api-key"
+export BUNNY_STORAGE_ZONE="your-storage-zone-name"
+export BUNNY_STORAGE_REGION="de"  # Optional, defaults to "de" (Falkenstein)
+```
+
+## Running the Example
+
+Start the local server:
+
+```bash
+BUNNY_STORAGE_API_KEY="your-key" BUNNY_STORAGE_ZONE="your-zone" composer start
+```
+
+Then visit http://localhost:8000 in your browser.
+
+## What This Example Does
+
+1. Displays an HTML form for file upload
+2. Handles the form submission
+3. Uploads the file to Bunny Storage in an `uploads/` directory
+4. Lists all uploaded files with their details
+5. Provides download links for each file

--- a/examples/form-upload/README.md
+++ b/examples/form-upload/README.md
@@ -1,4 +1,4 @@
-# File Upload Example
+# Form Upload Example
 
 This example demonstrates how to handle file uploads from an HTML form and store them in Bunny Storage.
 
@@ -36,8 +36,7 @@ Then visit http://localhost:8000 in your browser.
 
 ## What This Example Does
 
-1. Displays an HTML form for file upload
-2. Handles the form submission
+1. Displays a simple HTML form for file upload
+2. Handles the form submission via POST
 3. Uploads the file to Bunny Storage in an `uploads/` directory
-4. Lists all uploaded files with their details
-5. Provides download links for each file
+4. Shows a success or error message

--- a/examples/form-upload/composer.json
+++ b/examples/form-upload/composer.json
@@ -1,18 +1,11 @@
 {
-    "name": "bunnycdn/storage-example-file-upload",
-    "description": "File upload form example for Bunny Storage SDK",
-    "type": "project",
-    "require": {
-        "php": ">=8.1",
-        "bunnycdn/storage": "*"
-    },
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../../"
-        }
-    ],
-    "scripts": {
-        "start": "php -S localhost:8000 index.php"
-    }
+  "name": "bunny/storage-form-upload-example",
+  "description": "Form upload example for Bunny Storage PHP SDK",
+  "type": "project",
+  "require": {
+    "php": ">=8.1"
+  },
+  "scripts": {
+    "start": "php -S localhost:8000 index.php"
+  }
 }

--- a/examples/form-upload/composer.json
+++ b/examples/form-upload/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "bunnycdn/storage-example-file-upload",
+    "description": "File upload form example for Bunny Storage SDK",
+    "type": "project",
+    "require": {
+        "php": ">=8.1",
+        "bunnycdn/storage": "*"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../"
+        }
+    ],
+    "scripts": {
+        "start": "php -S localhost:8000 index.php"
+    }
+}

--- a/examples/form-upload/index.php
+++ b/examples/form-upload/index.php
@@ -32,7 +32,7 @@ $regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
 $client = new Client($apiKey, $storageZone, $regionConstant);
 
 $message = "";
-$messageType = "";
+$success = false;
 
 if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_FILES["file"])) {
     $file = $_FILES["file"];
@@ -45,60 +45,13 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_FILES["file"])) {
         try {
             $client->upload($tmpPath, $remotePath);
             $message = "File '{$fileName}' uploaded successfully!";
-            $messageType = "success";
+            $success = true;
         } catch (Exception $e) {
             $message = "Upload failed: {$e->getMessage()}";
-            $messageType = "error";
         }
     } else {
-        $errorMessage = getUploadErrorMessage($file["error"]);
-        $message = "Upload error: {$errorMessage}";
-        $messageType = "error";
+        $message = "Upload error occurred.";
     }
-}
-
-if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["delete"])) {
-    $fileToDelete = $_POST["delete"];
-    try {
-        $client->delete("uploads/{$fileToDelete}");
-        $message = "File '{$fileToDelete}' deleted successfully!";
-        $messageType = "success";
-    } catch (Exception $e) {
-        $message = "Delete failed: {$e->getMessage()}";
-        $messageType = "error";
-    }
-}
-
-$files = [];
-try {
-    $files = $client->listFiles("uploads/");
-} catch (Exception $e) {
-    // Directory might not exist yet
-}
-
-function getUploadErrorMessage(int $errorCode): string
-{
-    return match ($errorCode) {
-        UPLOAD_ERR_INI_SIZE => "File exceeds upload_max_filesize directive",
-        UPLOAD_ERR_FORM_SIZE => "File exceeds MAX_FILE_SIZE directive",
-        UPLOAD_ERR_PARTIAL => "File was only partially uploaded",
-        UPLOAD_ERR_NO_FILE => "No file was uploaded",
-        UPLOAD_ERR_NO_TMP_DIR => "Missing temporary folder",
-        UPLOAD_ERR_CANT_WRITE => "Failed to write file to disk",
-        UPLOAD_ERR_EXTENSION => "A PHP extension stopped the upload",
-        default => "Unknown upload error",
-    };
-}
-
-function formatBytes(int $bytes, int $precision = 2): string
-{
-    $units = ["B", "KB", "MB", "GB", "TB"];
-    $bytes = max($bytes, 0);
-    $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
-    $pow = min($pow, count($units) - 1);
-    $bytes /= 1 << 10 * $pow;
-
-    return round($bytes, $precision) . " " . $units[$pow];
 }
 ?>
 <!DOCTYPE html>
@@ -106,110 +59,20 @@ function formatBytes(int $bytes, int $precision = 2): string
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Bunny Storage - File Upload Example</title>
-    <style>
-        * { box-sizing: border-box; }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            max-width: 800px;
-            margin: 0 auto;
-            padding: 20px;
-            background: #f5f5f5;
-        }
-        h1 { color: #333; }
-        .card {
-            background: white;
-            border-radius: 8px;
-            padding: 20px;
-            margin-bottom: 20px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-        }
-        .message {
-            padding: 12px;
-            border-radius: 4px;
-            margin-bottom: 20px;
-        }
-        .message.success { background: #d4edda; color: #155724; }
-        .message.error { background: #f8d7da; color: #721c24; }
-        form { display: flex; gap: 10px; align-items: center; }
-        input[type="file"] { flex: 1; }
-        button {
-            background: #ff6600;
-            color: white;
-            border: none;
-            padding: 10px 20px;
-            border-radius: 4px;
-            cursor: pointer;
-        }
-        button:hover { background: #e55c00; }
-        button.delete {
-            background: #dc3545;
-            padding: 5px 10px;
-            font-size: 12px;
-        }
-        button.delete:hover { background: #c82333; }
-        table { width: 100%; border-collapse: collapse; }
-        th, td { padding: 12px; text-align: left; border-bottom: 1px solid #eee; }
-        th { background: #f8f9fa; font-weight: 600; }
-        .empty { color: #666; font-style: italic; }
-    </style>
+    <title>Bunny Storage - Form Upload</title>
 </head>
 <body>
-    <h1>Bunny Storage - File Upload</h1>
+    <h1>Upload a File</h1>
 
     <?php if ($message): ?>
-        <div class="message <?= $messageType ?>"><?= htmlspecialchars(
-    $message,
-) ?></div>
+        <p style="color: <?= $success
+            ? "green"
+            : "red" ?>"><?= htmlspecialchars($message) ?></p>
     <?php endif; ?>
 
-    <div class="card">
-        <h2>Upload a File</h2>
-        <form method="POST" enctype="multipart/form-data">
-            <input type="file" name="file" required>
-            <button type="submit">Upload</button>
-        </form>
-    </div>
-
-    <div class="card">
-        <h2>Uploaded Files</h2>
-        <?php if (empty($files)): ?>
-            <p class="empty">No files uploaded yet.</p>
-        <?php else: ?>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Size</th>
-                        <th>Modified</th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ($files as $file): ?>
-                        <?php if (!$file->isDirectory()): ?>
-                            <tr>
-                                <td><?= htmlspecialchars(
-                                    $file->getName(),
-                                ) ?></td>
-                                <td><?= formatBytes($file->getSize()) ?></td>
-                                <td><?= $file
-                                    ->getDateModified()
-                                    ->format("Y-m-d H:i") ?></td>
-                                <td>
-                                    <form method="POST" style="display:inline;">
-                                        <input type="hidden" name="delete" value="<?= htmlspecialchars(
-                                            $file->getName(),
-                                        ) ?>">
-                                        <button type="submit" class="delete" onclick="return confirm('Delete this file?')">Delete</button>
-                                    </form>
-                                </td>
-                            </tr>
-                        <?php endif; ?>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
-        <?php endif; ?>
-    </div>
+    <form method="POST" enctype="multipart/form-data">
+        <input type="file" name="file" required>
+        <button type="submit">Upload</button>
+    </form>
 </body>
 </html>

--- a/examples/form-upload/index.php
+++ b/examples/form-upload/index.php
@@ -1,0 +1,215 @@
+<?php
+
+require_once __DIR__ . "/../../vendor/autoload.php";
+
+use Bunny\Storage\Client;
+use Bunny\Storage\Region;
+
+$apiKey = getenv("BUNNY_STORAGE_API_KEY");
+$storageZone = getenv("BUNNY_STORAGE_ZONE");
+$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+
+if (!$apiKey || !$storageZone) {
+    die(
+        "Error: BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required."
+    );
+}
+
+$regionMap = [
+    "de" => Region::FALKENSTEIN,
+    "uk" => Region::LONDON,
+    "se" => Region::STOCKHOLM,
+    "ny" => Region::NEW_YORK,
+    "la" => Region::LOS_ANGELES,
+    "sg" => Region::SINGAPORE,
+    "syd" => Region::SYDNEY,
+    "br" => Region::SAO_PAULO,
+    "jh" => Region::JOHANNESBURG,
+];
+
+$regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
+
+$client = new Client($apiKey, $storageZone, $regionConstant);
+
+$message = "";
+$messageType = "";
+
+if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_FILES["file"])) {
+    $file = $_FILES["file"];
+
+    if ($file["error"] === UPLOAD_ERR_OK) {
+        $tmpPath = $file["tmp_name"];
+        $fileName = basename($file["name"]);
+        $remotePath = "uploads/{$fileName}";
+
+        try {
+            $client->upload($tmpPath, $remotePath);
+            $message = "File '{$fileName}' uploaded successfully!";
+            $messageType = "success";
+        } catch (Exception $e) {
+            $message = "Upload failed: {$e->getMessage()}";
+            $messageType = "error";
+        }
+    } else {
+        $errorMessage = getUploadErrorMessage($file["error"]);
+        $message = "Upload error: {$errorMessage}";
+        $messageType = "error";
+    }
+}
+
+if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["delete"])) {
+    $fileToDelete = $_POST["delete"];
+    try {
+        $client->delete("uploads/{$fileToDelete}");
+        $message = "File '{$fileToDelete}' deleted successfully!";
+        $messageType = "success";
+    } catch (Exception $e) {
+        $message = "Delete failed: {$e->getMessage()}";
+        $messageType = "error";
+    }
+}
+
+$files = [];
+try {
+    $files = $client->listFiles("uploads/");
+} catch (Exception $e) {
+    // Directory might not exist yet
+}
+
+function getUploadErrorMessage(int $errorCode): string
+{
+    return match ($errorCode) {
+        UPLOAD_ERR_INI_SIZE => "File exceeds upload_max_filesize directive",
+        UPLOAD_ERR_FORM_SIZE => "File exceeds MAX_FILE_SIZE directive",
+        UPLOAD_ERR_PARTIAL => "File was only partially uploaded",
+        UPLOAD_ERR_NO_FILE => "No file was uploaded",
+        UPLOAD_ERR_NO_TMP_DIR => "Missing temporary folder",
+        UPLOAD_ERR_CANT_WRITE => "Failed to write file to disk",
+        UPLOAD_ERR_EXTENSION => "A PHP extension stopped the upload",
+        default => "Unknown upload error",
+    };
+}
+
+function formatBytes(int $bytes, int $precision = 2): string
+{
+    $units = ["B", "KB", "MB", "GB", "TB"];
+    $bytes = max($bytes, 0);
+    $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
+    $pow = min($pow, count($units) - 1);
+    $bytes /= 1 << 10 * $pow;
+
+    return round($bytes, $precision) . " " . $units[$pow];
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bunny Storage - File Upload Example</title>
+    <style>
+        * { box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        h1 { color: #333; }
+        .card {
+            background: white;
+            border-radius: 8px;
+            padding: 20px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .message {
+            padding: 12px;
+            border-radius: 4px;
+            margin-bottom: 20px;
+        }
+        .message.success { background: #d4edda; color: #155724; }
+        .message.error { background: #f8d7da; color: #721c24; }
+        form { display: flex; gap: 10px; align-items: center; }
+        input[type="file"] { flex: 1; }
+        button {
+            background: #ff6600;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        button:hover { background: #e55c00; }
+        button.delete {
+            background: #dc3545;
+            padding: 5px 10px;
+            font-size: 12px;
+        }
+        button.delete:hover { background: #c82333; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { padding: 12px; text-align: left; border-bottom: 1px solid #eee; }
+        th { background: #f8f9fa; font-weight: 600; }
+        .empty { color: #666; font-style: italic; }
+    </style>
+</head>
+<body>
+    <h1>Bunny Storage - File Upload</h1>
+
+    <?php if ($message): ?>
+        <div class="message <?= $messageType ?>"><?= htmlspecialchars(
+    $message,
+) ?></div>
+    <?php endif; ?>
+
+    <div class="card">
+        <h2>Upload a File</h2>
+        <form method="POST" enctype="multipart/form-data">
+            <input type="file" name="file" required>
+            <button type="submit">Upload</button>
+        </form>
+    </div>
+
+    <div class="card">
+        <h2>Uploaded Files</h2>
+        <?php if (empty($files)): ?>
+            <p class="empty">No files uploaded yet.</p>
+        <?php else: ?>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Size</th>
+                        <th>Modified</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($files as $file): ?>
+                        <?php if (!$file->isDirectory()): ?>
+                            <tr>
+                                <td><?= htmlspecialchars(
+                                    $file->getName(),
+                                ) ?></td>
+                                <td><?= formatBytes($file->getSize()) ?></td>
+                                <td><?= $file
+                                    ->getDateModified()
+                                    ->format("Y-m-d H:i") ?></td>
+                                <td>
+                                    <form method="POST" style="display:inline;">
+                                        <input type="hidden" name="delete" value="<?= htmlspecialchars(
+                                            $file->getName(),
+                                        ) ?>">
+                                        <button type="submit" class="delete" onclick="return confirm('Delete this file?')">Delete</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
+    </div>
+</body>
+</html>

--- a/examples/form-upload/index.php
+++ b/examples/form-upload/index.php
@@ -1,45 +1,45 @@
 <?php
 
-require_once __DIR__ . "/../../vendor/autoload.php";
+require_once __DIR__.'/../../vendor/autoload.php';
 
 use Bunny\Storage\Client;
 use Bunny\Storage\Region;
 
-$apiKey = getenv("BUNNY_STORAGE_API_KEY");
-$storageZone = getenv("BUNNY_STORAGE_ZONE");
-$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+$apiKey = getenv('BUNNY_STORAGE_API_KEY');
+$storageZone = getenv('BUNNY_STORAGE_ZONE');
+$region = getenv('BUNNY_STORAGE_REGION') ?: 'de';
 
 if (!$apiKey || !$storageZone) {
-    die(
-        "Error: BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required."
+    exit(
+        'Error: BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.'
     );
 }
 
 $regionMap = [
-    "de" => Region::FALKENSTEIN,
-    "uk" => Region::LONDON,
-    "se" => Region::STOCKHOLM,
-    "ny" => Region::NEW_YORK,
-    "la" => Region::LOS_ANGELES,
-    "sg" => Region::SINGAPORE,
-    "syd" => Region::SYDNEY,
-    "br" => Region::SAO_PAULO,
-    "jh" => Region::JOHANNESBURG,
+    'de' => Region::FALKENSTEIN,
+    'uk' => Region::LONDON,
+    'se' => Region::STOCKHOLM,
+    'ny' => Region::NEW_YORK,
+    'la' => Region::LOS_ANGELES,
+    'sg' => Region::SINGAPORE,
+    'syd' => Region::SYDNEY,
+    'br' => Region::SAO_PAULO,
+    'jh' => Region::JOHANNESBURG,
 ];
 
 $regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
 
 $client = new Client($apiKey, $storageZone, $regionConstant);
 
-$message = "";
+$message = '';
 $success = false;
 
-if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_FILES["file"])) {
-    $file = $_FILES["file"];
+if ('POST' === $_SERVER['REQUEST_METHOD'] && isset($_FILES['file'])) {
+    $file = $_FILES['file'];
 
-    if ($file["error"] === UPLOAD_ERR_OK) {
-        $tmpPath = $file["tmp_name"];
-        $fileName = basename($file["name"]);
+    if (UPLOAD_ERR_OK === $file['error']) {
+        $tmpPath = $file['tmp_name'];
+        $fileName = basename($file['name']);
         $remotePath = "uploads/{$fileName}";
 
         try {
@@ -50,7 +50,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_FILES["file"])) {
             $message = "Upload failed: {$e->getMessage()}";
         }
     } else {
-        $message = "Upload error occurred.";
+        $message = 'Upload error occurred.';
     }
 }
 ?>
@@ -64,11 +64,11 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_FILES["file"])) {
 <body>
     <h1>Upload a File</h1>
 
-    <?php if ($message): ?>
-        <p style="color: <?= $success
-            ? "green"
-            : "red" ?>"><?= htmlspecialchars($message) ?></p>
-    <?php endif; ?>
+    <?php if ($message) { ?>
+        <p style="color: <?php echo $success
+            ? 'green'
+            : 'red'; ?>"><?php echo htmlspecialchars($message); ?></p>
+    <?php } ?>
 
     <form method="POST" enctype="multipart/form-data">
         <input type="file" name="file" required>

--- a/examples/kitchen-sink/README.md
+++ b/examples/kitchen-sink/README.md
@@ -1,0 +1,50 @@
+# Kitchen Sink Example
+
+A comprehensive example demonstrating multiple Bunny Storage operations in a single web interface: uploading, listing, and deleting files.
+
+## Prerequisites
+
+- PHP 8.1 or higher
+- Composer
+- A Bunny Storage zone with API credentials
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+composer install
+```
+
+2. Set the required environment variables:
+
+```bash
+export BUNNY_STORAGE_API_KEY="your-storage-api-key"
+export BUNNY_STORAGE_ZONE="your-storage-zone-name"
+export BUNNY_STORAGE_REGION="de"  # Optional, defaults to "de" (Falkenstein)
+```
+
+## Running the Example
+
+Start the local server:
+
+```bash
+BUNNY_STORAGE_API_KEY="your-key" BUNNY_STORAGE_ZONE="your-zone" composer start
+```
+
+Then visit http://localhost:8000 in your browser.
+
+## Features
+
+- **Upload**: HTML form for uploading files to Bunny Storage
+- **List**: Displays all uploaded files in a table with name, size, and modified date
+- **Delete**: Remove files directly from the interface
+
+## What This Example Demonstrates
+
+1. Handling HTML form file uploads with `$_FILES`
+2. Uploading files using `$client->upload()`
+3. Listing files using `$client->listFiles()`
+4. Deleting files using `$client->delete()`
+5. Proper error handling for upload errors
+6. Formatting file sizes for display

--- a/examples/kitchen-sink/composer.json
+++ b/examples/kitchen-sink/composer.json
@@ -1,0 +1,18 @@
+{
+  "name": "bunnycdn/storage-example-file-upload",
+  "description": "File upload form example for Bunny Storage SDK",
+  "type": "project",
+  "require": {
+    "php": ">=8.1",
+    "bunnycdn/storage": "*"
+  },
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../../"
+    }
+  ],
+  "scripts": {
+    "start": "php -S localhost:8000 index.php"
+  }
+}

--- a/examples/kitchen-sink/index.php
+++ b/examples/kitchen-sink/index.php
@@ -1,104 +1,105 @@
 <?php
 
-require_once __DIR__ . "/../../vendor/autoload.php";
+require_once __DIR__.'/../../vendor/autoload.php';
 
 use Bunny\Storage\Client;
 use Bunny\Storage\Region;
 
-$apiKey = getenv("BUNNY_STORAGE_API_KEY");
-$storageZone = getenv("BUNNY_STORAGE_ZONE");
-$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+$apiKey = getenv('BUNNY_STORAGE_API_KEY');
+$storageZone = getenv('BUNNY_STORAGE_ZONE');
+$region = getenv('BUNNY_STORAGE_REGION') ?: 'de';
 
 if (!$apiKey || !$storageZone) {
-    die(
-        "Error: BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required."
+    exit(
+        'Error: BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.'
     );
 }
 
 $regionMap = [
-    "de" => Region::FALKENSTEIN,
-    "uk" => Region::LONDON,
-    "se" => Region::STOCKHOLM,
-    "ny" => Region::NEW_YORK,
-    "la" => Region::LOS_ANGELES,
-    "sg" => Region::SINGAPORE,
-    "syd" => Region::SYDNEY,
-    "br" => Region::SAO_PAULO,
-    "jh" => Region::JOHANNESBURG,
+    'de' => Region::FALKENSTEIN,
+    'uk' => Region::LONDON,
+    'se' => Region::STOCKHOLM,
+    'ny' => Region::NEW_YORK,
+    'la' => Region::LOS_ANGELES,
+    'sg' => Region::SINGAPORE,
+    'syd' => Region::SYDNEY,
+    'br' => Region::SAO_PAULO,
+    'jh' => Region::JOHANNESBURG,
 ];
 
 $regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
 
 $client = new Client($apiKey, $storageZone, $regionConstant);
 
-$message = "";
-$messageType = "";
+$message = '';
+$messageType = '';
 
-if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_FILES["file"])) {
-    $file = $_FILES["file"];
+if ('POST' === $_SERVER['REQUEST_METHOD'] && isset($_FILES['file'])) {
+    $file = $_FILES['file'];
 
-    if ($file["error"] === UPLOAD_ERR_OK) {
-        $tmpPath = $file["tmp_name"];
-        $fileName = basename($file["name"]);
+    if (UPLOAD_ERR_OK === $file['error']) {
+        $tmpPath = $file['tmp_name'];
+        $fileName = basename($file['name']);
         $remotePath = "uploads/{$fileName}";
 
         try {
             $client->upload($tmpPath, $remotePath);
             $message = "File '{$fileName}' uploaded successfully!";
-            $messageType = "success";
+            $messageType = 'success';
         } catch (Exception $e) {
             $message = "Upload failed: {$e->getMessage()}";
-            $messageType = "error";
+            $messageType = 'error';
         }
     } else {
-        $errorMessage = getUploadErrorMessage($file["error"]);
+        $errorMessage = getUploadErrorMessage($file['error']);
         $message = "Upload error: {$errorMessage}";
-        $messageType = "error";
+        $messageType = 'error';
     }
 }
 
-if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["delete"])) {
-    $fileToDelete = $_POST["delete"];
+if ('POST' === $_SERVER['REQUEST_METHOD'] && isset($_POST['delete'])) {
+    $fileToDelete = $_POST['delete'];
     try {
         $client->delete("uploads/{$fileToDelete}");
         $message = "File '{$fileToDelete}' deleted successfully!";
-        $messageType = "success";
+        $messageType = 'success';
     } catch (Exception $e) {
         $message = "Delete failed: {$e->getMessage()}";
-        $messageType = "error";
+        $messageType = 'error';
     }
 }
 
 $files = [];
 try {
-    $files = $client->listFiles("uploads/");
+    $files = $client->listFiles('uploads/');
 } catch (Exception $e) {
     // Directory might not exist yet
 }
 
 function getUploadErrorMessage(int $errorCode): string
 {
-    return match ($errorCode) {
-        UPLOAD_ERR_INI_SIZE => "File exceeds upload_max_filesize directive",
-        UPLOAD_ERR_FORM_SIZE => "File exceeds MAX_FILE_SIZE directive",
-        UPLOAD_ERR_PARTIAL => "File was only partially uploaded",
-        UPLOAD_ERR_NO_FILE => "No file was uploaded",
-        UPLOAD_ERR_NO_TMP_DIR => "Missing temporary folder",
-        UPLOAD_ERR_CANT_WRITE => "Failed to write file to disk",
-        UPLOAD_ERR_EXTENSION => "A PHP extension stopped the upload",
-        default => "Unknown upload error",
-    };
+    $errors = [
+        UPLOAD_ERR_INI_SIZE => 'File exceeds upload_max_filesize directive',
+        UPLOAD_ERR_FORM_SIZE => 'File exceeds MAX_FILE_SIZE directive',
+        UPLOAD_ERR_PARTIAL => 'File was only partially uploaded',
+        UPLOAD_ERR_NO_FILE => 'No file was uploaded',
+        UPLOAD_ERR_NO_TMP_DIR => 'Missing temporary folder',
+        UPLOAD_ERR_CANT_WRITE => 'Failed to write file to disk',
+        UPLOAD_ERR_EXTENSION => 'A PHP extension stopped the upload',
+    ];
+
+    return $errors[$errorCode] ?? 'Unknown upload error';
 }
 
 function formatBytes(int $bytes, int $precision = 2): string
 {
-    $units = ["B", "KB", "MB", "GB", "TB"];
+    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
     $bytes = max($bytes, 0);
     $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
     $pow = min($pow, count($units) - 1);
     $bytes /= 1 << 10 * $pow;
 
-    return round($bytes, $precision) . " " . $units[$pow];
+    return round($bytes, $precision).' '.$units[$pow];
 }
 ?>
 <!DOCTYPE html>
@@ -157,11 +158,11 @@ function formatBytes(int $bytes, int $precision = 2): string
 <body>
     <h1>Bunny Storage - File Upload</h1>
 
-    <?php if ($message): ?>
-        <div class="message <?= $messageType ?>"><?= htmlspecialchars(
-    $message,
-) ?></div>
-    <?php endif; ?>
+    <?php if ($message) { ?>
+        <div class="message <?php echo $messageType; ?>"><?php echo htmlspecialchars(
+            $message,
+        ); ?></div>
+    <?php } ?>
 
     <div class="card">
         <h2>Upload a File</h2>
@@ -173,9 +174,9 @@ function formatBytes(int $bytes, int $precision = 2): string
 
     <div class="card">
         <h2>Uploaded Files</h2>
-        <?php if (empty($files)): ?>
+        <?php if (empty($files)) { ?>
             <p class="empty">No files uploaded yet.</p>
-        <?php else: ?>
+        <?php } else { ?>
             <table>
                 <thead>
                     <tr>
@@ -186,30 +187,30 @@ function formatBytes(int $bytes, int $precision = 2): string
                     </tr>
                 </thead>
                 <tbody>
-                    <?php foreach ($files as $file): ?>
-                        <?php if (!$file->isDirectory()): ?>
+                    <?php foreach ($files as $file) { ?>
+                        <?php if (!$file->isDirectory()) { ?>
                             <tr>
-                                <td><?= htmlspecialchars(
+                                <td><?php echo htmlspecialchars(
                                     $file->getName(),
-                                ) ?></td>
-                                <td><?= formatBytes($file->getSize()) ?></td>
-                                <td><?= $file
+                                ); ?></td>
+                                <td><?php echo formatBytes($file->getSize()); ?></td>
+                                <td><?php echo $file
                                     ->getDateModified()
-                                    ->format("Y-m-d H:i") ?></td>
+                                    ->format('Y-m-d H:i'); ?></td>
                                 <td>
                                     <form method="POST" style="display:inline;">
-                                        <input type="hidden" name="delete" value="<?= htmlspecialchars(
+                                        <input type="hidden" name="delete" value="<?php echo htmlspecialchars(
                                             $file->getName(),
-                                        ) ?>">
+                                        ); ?>">
                                         <button type="submit" class="delete" onclick="return confirm('Delete this file?')">Delete</button>
                                     </form>
                                 </td>
                             </tr>
-                        <?php endif; ?>
-                    <?php endforeach; ?>
+                        <?php } ?>
+                    <?php } ?>
                 </tbody>
             </table>
-        <?php endif; ?>
+        <?php } ?>
     </div>
 </body>
 </html>

--- a/examples/kitchen-sink/index.php
+++ b/examples/kitchen-sink/index.php
@@ -1,0 +1,215 @@
+<?php
+
+require_once __DIR__ . "/../../vendor/autoload.php";
+
+use Bunny\Storage\Client;
+use Bunny\Storage\Region;
+
+$apiKey = getenv("BUNNY_STORAGE_API_KEY");
+$storageZone = getenv("BUNNY_STORAGE_ZONE");
+$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+
+if (!$apiKey || !$storageZone) {
+    die(
+        "Error: BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required."
+    );
+}
+
+$regionMap = [
+    "de" => Region::FALKENSTEIN,
+    "uk" => Region::LONDON,
+    "se" => Region::STOCKHOLM,
+    "ny" => Region::NEW_YORK,
+    "la" => Region::LOS_ANGELES,
+    "sg" => Region::SINGAPORE,
+    "syd" => Region::SYDNEY,
+    "br" => Region::SAO_PAULO,
+    "jh" => Region::JOHANNESBURG,
+];
+
+$regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
+
+$client = new Client($apiKey, $storageZone, $regionConstant);
+
+$message = "";
+$messageType = "";
+
+if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_FILES["file"])) {
+    $file = $_FILES["file"];
+
+    if ($file["error"] === UPLOAD_ERR_OK) {
+        $tmpPath = $file["tmp_name"];
+        $fileName = basename($file["name"]);
+        $remotePath = "uploads/{$fileName}";
+
+        try {
+            $client->upload($tmpPath, $remotePath);
+            $message = "File '{$fileName}' uploaded successfully!";
+            $messageType = "success";
+        } catch (Exception $e) {
+            $message = "Upload failed: {$e->getMessage()}";
+            $messageType = "error";
+        }
+    } else {
+        $errorMessage = getUploadErrorMessage($file["error"]);
+        $message = "Upload error: {$errorMessage}";
+        $messageType = "error";
+    }
+}
+
+if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST["delete"])) {
+    $fileToDelete = $_POST["delete"];
+    try {
+        $client->delete("uploads/{$fileToDelete}");
+        $message = "File '{$fileToDelete}' deleted successfully!";
+        $messageType = "success";
+    } catch (Exception $e) {
+        $message = "Delete failed: {$e->getMessage()}";
+        $messageType = "error";
+    }
+}
+
+$files = [];
+try {
+    $files = $client->listFiles("uploads/");
+} catch (Exception $e) {
+    // Directory might not exist yet
+}
+
+function getUploadErrorMessage(int $errorCode): string
+{
+    return match ($errorCode) {
+        UPLOAD_ERR_INI_SIZE => "File exceeds upload_max_filesize directive",
+        UPLOAD_ERR_FORM_SIZE => "File exceeds MAX_FILE_SIZE directive",
+        UPLOAD_ERR_PARTIAL => "File was only partially uploaded",
+        UPLOAD_ERR_NO_FILE => "No file was uploaded",
+        UPLOAD_ERR_NO_TMP_DIR => "Missing temporary folder",
+        UPLOAD_ERR_CANT_WRITE => "Failed to write file to disk",
+        UPLOAD_ERR_EXTENSION => "A PHP extension stopped the upload",
+        default => "Unknown upload error",
+    };
+}
+
+function formatBytes(int $bytes, int $precision = 2): string
+{
+    $units = ["B", "KB", "MB", "GB", "TB"];
+    $bytes = max($bytes, 0);
+    $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
+    $pow = min($pow, count($units) - 1);
+    $bytes /= 1 << 10 * $pow;
+
+    return round($bytes, $precision) . " " . $units[$pow];
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bunny Storage - File Upload Example</title>
+    <style>
+        * { box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        h1 { color: #333; }
+        .card {
+            background: white;
+            border-radius: 8px;
+            padding: 20px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .message {
+            padding: 12px;
+            border-radius: 4px;
+            margin-bottom: 20px;
+        }
+        .message.success { background: #d4edda; color: #155724; }
+        .message.error { background: #f8d7da; color: #721c24; }
+        form { display: flex; gap: 10px; align-items: center; }
+        input[type="file"] { flex: 1; }
+        button {
+            background: #ff6600;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        button:hover { background: #e55c00; }
+        button.delete {
+            background: #dc3545;
+            padding: 5px 10px;
+            font-size: 12px;
+        }
+        button.delete:hover { background: #c82333; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { padding: 12px; text-align: left; border-bottom: 1px solid #eee; }
+        th { background: #f8f9fa; font-weight: 600; }
+        .empty { color: #666; font-style: italic; }
+    </style>
+</head>
+<body>
+    <h1>Bunny Storage - File Upload</h1>
+
+    <?php if ($message): ?>
+        <div class="message <?= $messageType ?>"><?= htmlspecialchars(
+    $message,
+) ?></div>
+    <?php endif; ?>
+
+    <div class="card">
+        <h2>Upload a File</h2>
+        <form method="POST" enctype="multipart/form-data">
+            <input type="file" name="file" required>
+            <button type="submit">Upload</button>
+        </form>
+    </div>
+
+    <div class="card">
+        <h2>Uploaded Files</h2>
+        <?php if (empty($files)): ?>
+            <p class="empty">No files uploaded yet.</p>
+        <?php else: ?>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Size</th>
+                        <th>Modified</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($files as $file): ?>
+                        <?php if (!$file->isDirectory()): ?>
+                            <tr>
+                                <td><?= htmlspecialchars(
+                                    $file->getName(),
+                                ) ?></td>
+                                <td><?= formatBytes($file->getSize()) ?></td>
+                                <td><?= $file
+                                    ->getDateModified()
+                                    ->format("Y-m-d H:i") ?></td>
+                                <td>
+                                    <form method="POST" style="display:inline;">
+                                        <input type="hidden" name="delete" value="<?= htmlspecialchars(
+                                            $file->getName(),
+                                        ) ?>">
+                                        <button type="submit" class="delete" onclick="return confirm('Delete this file?')">Delete</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        <?php endif; ?>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
+    </div>
+</body>
+</html>

--- a/examples/list-files/README.md
+++ b/examples/list-files/README.md
@@ -1,0 +1,62 @@
+# List Files Example
+
+This example demonstrates how to list files and directories in Bunny Storage.
+
+## Prerequisites
+
+- PHP 8.1 or higher
+- Composer
+- A Bunny Storage zone with API credentials
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+composer install
+```
+
+2. Set the required environment variables:
+
+```bash
+export BUNNY_STORAGE_API_KEY="your-storage-api-key"
+export BUNNY_STORAGE_ZONE="your-storage-zone-name"
+export BUNNY_STORAGE_REGION="de"  # Optional, defaults to "de" (Falkenstein)
+```
+
+## Available Regions
+
+| Code  | Location                |
+| ----- | ----------------------- |
+| `de`  | Falkenstein (default)   |
+| `uk`  | London                  |
+| `se`  | Stockholm               |
+| `ny`  | New York                |
+| `la`  | Los Angeles             |
+| `sg`  | Singapore               |
+| `syd` | Sydney                  |
+| `br`  | Sao Paulo               |
+| `jh`  | Johannesburg            |
+
+## Running the Example
+
+Run directly with PHP:
+
+```bash
+BUNNY_STORAGE_API_KEY="your-key" BUNNY_STORAGE_ZONE="your-zone" php index.php
+```
+
+Or start a local server:
+
+```bash
+BUNNY_STORAGE_API_KEY="your-key" BUNNY_STORAGE_ZONE="your-zone" composer start
+```
+
+Then visit http://localhost:8000 in your browser.
+
+## What This Example Does
+
+1. Connects to your storage zone
+2. Lists all files and directories in the root
+3. Displays file metadata (name, size, checksum, dates)
+4. Shows how to navigate subdirectories

--- a/examples/list-files/composer.json
+++ b/examples/list-files/composer.json
@@ -1,0 +1,18 @@
+{
+  "name": "bunnycdn/storage-example-list-files",
+  "description": "List files example for Bunny Storage SDK",
+  "type": "project",
+  "require": {
+    "php": ">=8.1",
+    "bunnycdn/storage": "*"
+  },
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../../"
+    }
+  ],
+  "scripts": {
+    "start": "php -S localhost:8000 index.php"
+  }
+}

--- a/examples/list-files/index.php
+++ b/examples/list-files/index.php
@@ -1,0 +1,48 @@
+<?php
+
+require_once __DIR__ . "/../../vendor/autoload.php";
+
+use Bunny\Storage\Client;
+use Bunny\Storage\Region;
+
+$apiKey = getenv("BUNNY_STORAGE_API_KEY");
+$storageZone = getenv("BUNNY_STORAGE_ZONE");
+$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+
+if (!$apiKey || !$storageZone) {
+    die(
+        "Error: BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.\n"
+    );
+}
+
+$regionMap = [
+    "de" => Region::FALKENSTEIN,
+    "uk" => Region::LONDON,
+    "se" => Region::STOCKHOLM,
+    "ny" => Region::NEW_YORK,
+    "la" => Region::LOS_ANGELES,
+    "sg" => Region::SINGAPORE,
+    "syd" => Region::SYDNEY,
+    "br" => Region::SAO_PAULO,
+    "jh" => Region::JOHANNESBURG,
+];
+
+$regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
+
+$client = new Client($apiKey, $storageZone, $regionConstant);
+
+$directory = $_GET["directory"] ?? "/";
+$files = $client->listFiles($directory);
+
+$output = array_map(
+    fn($file) => [
+        "name" => $file->getName(),
+        "size" => $file->getSize(),
+        "isDirectory" => $file->isDirectory(),
+        "dateModified" => $file->getDateModified()->format("c"),
+    ],
+    $files,
+);
+
+header("Content-Type: application/json");
+echo json_encode($output, JSON_PRETTY_PRINT);

--- a/examples/list-files/index.php
+++ b/examples/list-files/index.php
@@ -1,48 +1,48 @@
 <?php
 
-require_once __DIR__ . "/../../vendor/autoload.php";
+require_once __DIR__.'/../../vendor/autoload.php';
 
 use Bunny\Storage\Client;
 use Bunny\Storage\Region;
 
-$apiKey = getenv("BUNNY_STORAGE_API_KEY");
-$storageZone = getenv("BUNNY_STORAGE_ZONE");
-$region = getenv("BUNNY_STORAGE_REGION") ?: "de";
+$apiKey = getenv('BUNNY_STORAGE_API_KEY');
+$storageZone = getenv('BUNNY_STORAGE_ZONE');
+$region = getenv('BUNNY_STORAGE_REGION') ?: 'de';
 
 if (!$apiKey || !$storageZone) {
-    die(
+    exit(
         "Error: BUNNY_STORAGE_API_KEY and BUNNY_STORAGE_ZONE environment variables are required.\n"
     );
 }
 
 $regionMap = [
-    "de" => Region::FALKENSTEIN,
-    "uk" => Region::LONDON,
-    "se" => Region::STOCKHOLM,
-    "ny" => Region::NEW_YORK,
-    "la" => Region::LOS_ANGELES,
-    "sg" => Region::SINGAPORE,
-    "syd" => Region::SYDNEY,
-    "br" => Region::SAO_PAULO,
-    "jh" => Region::JOHANNESBURG,
+    'de' => Region::FALKENSTEIN,
+    'uk' => Region::LONDON,
+    'se' => Region::STOCKHOLM,
+    'ny' => Region::NEW_YORK,
+    'la' => Region::LOS_ANGELES,
+    'sg' => Region::SINGAPORE,
+    'syd' => Region::SYDNEY,
+    'br' => Region::SAO_PAULO,
+    'jh' => Region::JOHANNESBURG,
 ];
 
 $regionConstant = $regionMap[$region] ?? Region::FALKENSTEIN;
 
 $client = new Client($apiKey, $storageZone, $regionConstant);
 
-$directory = $_GET["directory"] ?? "/";
+$directory = $_GET['directory'] ?? '/';
 $files = $client->listFiles($directory);
 
 $output = array_map(
-    fn($file) => [
-        "name" => $file->getName(),
-        "size" => $file->getSize(),
-        "isDirectory" => $file->isDirectory(),
-        "dateModified" => $file->getDateModified()->format("c"),
+    fn ($file) => [
+        'name' => $file->getName(),
+        'size' => $file->getSize(),
+        'isDirectory' => $file->isDirectory(),
+        'dateModified' => $file->getDateModified()->format('c'),
     ],
     $files,
 );
 
-header("Content-Type: application/json");
+header('Content-Type: application/json');
 echo json_encode($output, JSON_PRETTY_PRINT);


### PR DESCRIPTION
Along with some updates to documentation, it made sense to add an `examples` folder with some isolated examples users can run to test the different methods available on the PHP SDK.

My approach to these examples was to keep everything needed inside the `index.php` files so they could be easily copy/pasted into a users project, instead of a bootstrap file, plus some examples require more arguments than others.